### PR TITLE
(WIP) Add sqwiki features and rules to fetch labeled revision to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2414,6 +2414,45 @@ datasets/sqwiki.autolabeled_revisions.20k_2016.json: \
 		--verbose > \
 	datasets/sqwiki.autolabeled_revisions.20k_2016.json
 
+datasets/sqwiki.human_labeled_revisions.5k_2016.json:
+	./utility fetch_labels \
+		https://labels.wmflabs.org/campaigns/sqwiki/57/ > \
+	datasets/sqwiki.human_labeled_revisions.5k_2016.json
+
+datasets/sqwiki.human_labeled_revisions.5k_2016.no_review.json: \
+		datasets/sqwiki.human_labeled_revisions.5k_2016.json
+	cat datasets/sqwiki.human_labeled_revisions.5k_2016.json | \
+	grep '"needs_review": false' > \
+	datasets/sqwiki.human_labeled_revisions.5k_2016.no_review.json
+
+datasets/sqwiki.autolabeled_revisions.20k_2016.no_review.json: \
+		datasets/sqwiki.autolabeled_revisions.20k_2016.json
+	cat datasets/sqwiki.autolabeled_revisions.20k_2016.json | \
+	grep '"needs_review": false' > \
+	datasets/sqwiki.autolabeled_revisions.20k_2016.no_review.json
+
+datasets/sqwiki.labeled_revisions.20k_2016.json: \
+		datasets/sqwiki.human_labeled_revisions.5k_2016.no_review.json \
+		datasets/sqwiki.autolabeled_revisions.20k_2016.no_review.json \
+		datasets/sqwiki.human_labeled_revisions.5k_2016.json
+	( \
+	  ./utility merge_labels \
+	    datasets/sqwiki.human_labeled_revisions.5k_2016.no_review.json \
+	    datasets/sqwiki.autolabeled_revisions.20k_2016.no_review.json; \
+	  cat datasets/sqwiki.human_labeled_revisions.5k_2016.json | \
+	  grep '"needs_review": true' | shuf -rn 4558 \
+	) > datasets/sqwiki.labeled_revisions.20k_2016.json
+
+datasets/sqwiki.labeled_revisions.w_cache.20k_2016.json: \
+		datasets/sqwiki.labeled_revisions.20k_2016.json
+	cat datasets/sqwiki.labeled_revisions.20k_2016.json | \
+	revscoring extract \
+		editquality.feature_lists.sqwiki.damaging \
+		editquality.feature_lists.sqwiki.goodfaith \
+		--host https://sq.wikipedia.org \
+		--verbose > \
+	datasets/sqwiki.labeled_revisions.w_cache.20k_2016.json
+
 ################################# Swedish Wikipedia ###########################
 
 datasets/svwiki.sampled_revisions.40k_2016.json:

--- a/Makefile
+++ b/Makefile
@@ -2440,7 +2440,7 @@ datasets/sqwiki.labeled_revisions.20k_2016.json: \
 	    datasets/sqwiki.human_labeled_revisions.5k_2016.no_review.json \
 	    datasets/sqwiki.autolabeled_revisions.20k_2016.no_review.json; \
 	  cat datasets/sqwiki.human_labeled_revisions.5k_2016.json | \
-	  grep '"needs_review": true' | shuf -rn 4558 \
+	  grep '"needs_review": true' | head -n 20000 | shuf \
 	) > datasets/sqwiki.labeled_revisions.20k_2016.json
 
 datasets/sqwiki.labeled_revisions.w_cache.20k_2016.json: \

--- a/editquality/feature_lists/sqwiki.py
+++ b/editquality/feature_lists/sqwiki.py
@@ -1,0 +1,45 @@
+from revscoring.languages import albanian
+
+from . import enwiki, mediawiki, wikipedia, wikitext
+
+badwords = [
+    albanian.badwords.revision.diff.match_delta_sum,
+    albanian.badwords.revision.diff.match_delta_increase,
+    albanian.badwords.revision.diff.match_delta_decrease,
+    albanian.badwords.revision.diff.match_prop_delta_sum,
+    albanian.badwords.revision.diff.match_prop_delta_increase,
+    albanian.badwords.revision.diff.match_prop_delta_decrease
+]
+
+informals = [
+    albanian.informals.revision.diff.match_delta_sum,
+    albanian.informals.revision.diff.match_delta_increase,
+    albanian.informals.revision.diff.match_delta_decrease,
+    albanian.informals.revision.diff.match_prop_delta_sum,
+    albanian.informals.revision.diff.match_prop_delta_increase,
+    albanian.informals.revision.diff.match_prop_delta_decrease
+]
+
+dict_words = [
+    albanian.dictionary.revision.diff.dict_word_delta_sum,
+    albanian.dictionary.revision.diff.dict_word_delta_increase,
+    albanian.dictionary.revision.diff.dict_word_delta_decrease,
+    albanian.dictionary.revision.diff.dict_word_prop_delta_sum,
+    albanian.dictionary.revision.diff.dict_word_prop_delta_increase,
+    albanian.dictionary.revision.diff.dict_word_prop_delta_decrease,
+    albanian.dictionary.revision.diff.non_dict_word_delta_sum,
+    albanian.dictionary.revision.diff.non_dict_word_delta_increase,
+    albanian.dictionary.revision.diff.non_dict_word_delta_decrease,
+    albanian.dictionary.revision.diff.non_dict_word_prop_delta_sum,
+    albanian.dictionary.revision.diff.non_dict_word_prop_delta_increase,
+    albanian.dictionary.revision.diff.non_dict_word_prop_delta_decrease
+]
+
+damaging = wikipedia.page + \
+           wikitext.parent + wikitext.diff + mediawiki.user_rights + \
+           mediawiki.protected_user + mediawiki.comment + \
+           badwords + informals + dict_words + \
+           enwiki.badwords + enwiki.informals
+
+reverted = damaging
+goodfaith = damaging


### PR DESCRIPTION
* Adds rules to fetch human and autolabeled revisions to Makefile.
* Adds Albanian language features to feature_lists, incomplete without Albanian language assets in revscoring.

See - https://phabricator.wikimedia.org/T163009
Blocked by - https://phabricator.wikimedia.org/T168369