### PR TITLE
Add label param for enwiki goodfaith in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -586,6 +586,7 @@ tuning_reports/enwiki.goodfaith.md: \
 	revscoring tune \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.enwiki.goodfaith \
+		goodfaith \
 		--cv-timeout=60 \
 		--debug > $@
 


### PR DESCRIPTION
Label parameter missing to command for generating enwiki goodfaith tuning report in Makefile