### PR TITLE
Make autolabel use tqdm (progress bar)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ mwtypes >= 0.2.0, < 0.2.999
 mwreverts >= 0.0.6, < 0.0.999
 revscoring >= 1.3.17, < 1.3.999
 statistics >= 1.0.3, < 1.0.999
+tqdm >= 4.15.0, < 4.15.999
 mysqltsv >= 0.0.7, < 0.0.999
 para==0.0.5


### PR DESCRIPTION
It makes the verbose results to be flushed out after the autolabel is done, I spent lots of time to make it happen at the same time but it seems sys.stderr gets confused on order of flushing things (Several people in stackoverflow mentioned that too)

Bug: T172225