### PR TITLE
Add merge clause for huwiki

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1965,6 +1965,11 @@ datasets/huwiki.autolabeled_revisions.40k_2016.review.json: \
 		datasets/huwiki.autolabeled_revisions.40k_2016.json
 	cat $< | grep -E '"needs_review": (true|"True")' > $@
 
+
+datasets/huwiki.human_labeled_revisions.5k_2016.json:
+	./utility fetch_labels \
+		https://labels.wmflabs.org/campaigns/huwiki/33/ > $@
+
 datasets/huwiki.revisions_for_review.5k_2016.json: \
 		datasets/huwiki.autolabeled_revisions.40k_2016.review.json
 		datasets/huwiki.autolabeled_revisions.40k_2016.no_review.json
@@ -1974,6 +1979,21 @@ datasets/huwiki.revisions_for_review.5k_2016.json: \
 	 cat datasets/huwiki.autolabeled_revisions.40k_2016.no_review.json | \
 	 shuf -n 2500 \
 	) | shuf > $@
+
+datasets/huwiki.labeled_revisions.40k_2016.json: \
+		datasets/huwiki.human_labeled_revisions.5k_2016.json \
+		datasets/huwiki.autolabeled_revisions.40k_2016.no_review.json
+	./utility merge_labels $^ > $@
+
+datasets/huwiki.labeled_revisions.w_cache.40k_2016.json: \
+		datasets/huwiki.labeled_revisions.40k_2016.json
+	cat $< | \
+	revscoring extract \
+		editquality.feature_lists.huwiki.damaging \
+		editquality.feature_lists.huwiki.goodfaith \
+		--host https://hu.wikipedia.org \
+		--extractor $(max_extractors) \
+		--verbose > $@
 
 tuning_reports/huwiki.damaging.md: \
 		datasets/huwiki.labeled_revisions.w_cache.40k_2016.json
@@ -1998,10 +2018,10 @@ models/huwiki.damaging.gradient_boosting.model: \
 		editquality.feature_lists.huwiki.damaging \
 		damaging \
 		--version=$(damaging_major_minor).0 \
-		-p 'learning_rate=0.1' \
-		-p 'max_depth=3' \
+		-p 'learning_rate=0.01' \
+		-p 'max_depth=5' \
 		-p 'max_features="log2"' \
-		-p 'n_estimators=300' \
+		-p 'n_estimators=500' \
 		--label-weight "true=$(damaging_weight)" \
 		--pop-rate "true=0.01093805131" \
 		--pop-rate "false=0.98906194869" \

--- a/config/wikis/huwiki.yaml
+++ b/config/wikis/huwiki.yaml
@@ -3,8 +3,10 @@ label: Hungarian Wikipedia
 host: hu.wikipedia.org
 
 samples:
+    5k_2016:
+        labeling_campaign: https://labels.wmflabs.org/campaigns/huwiki/33/
     40k_2016:
-        quarry_url: "http://quarry.wmflabs.org/run/79645/output/0/json-lines?download=true"
+        quarry_url: http://quarry.wmflabs.org/run/79645/output/0/json-lines?download=true
 
 trusted_groups:
     - sysop
@@ -23,6 +25,11 @@ balanced_5k_set_for_review: true
 
 default_sample: 40k_2016
 review_sample: 5k_2016
+
+merged_samples:
+    40k_2016:
+        autolabeled_revisions: 40k_2016
+        human_labeled_revisions: 5k_2016
 
 models:
     damaging:


### PR DESCRIPTION
This patch adds rules to merge human- and auto-labeled data.

It's interesting what must have happened on the master branch: we had no rules for the `labeled_revisions` files, so I imagine that model training used stale data left in the directory from previous runs.  Our makefile generator should make this impossible, by asserting that exactly one method of producing the labeled-revisions files is present.