### PR TITLE
Fix merge_labels handling of degenerate case

### DIFF
--- a/editquality/utilities/tests/test_merge_labels.py
+++ b/editquality/utilities/tests/test_merge_labels.py
@@ -2,8 +2,8 @@ import pytest
 
 from .. import merge_labels
 
+
 @pytest.mark.parametrize("human, auto, expected", [
-    #[{"damaging": false, "goodfaith": true, "auto_labeled": false, "autolabel": {}, "rev_id": 12345}]
     # Discard data that needs review but has no labels.
     (
         [{"auto_labeled": False, "autolabel": {}, "rev_id": 12345}],
@@ -12,53 +12,129 @@ from .. import merge_labels
     ),
     # Guess good faith from not damaging.
     (
-        [{"damaging": False, "auto_labeled": False, "autolabel": {}, "rev_id": 12345}],
+        [{
+            "damaging": False,
+            "auto_labeled": False,
+            "autolabel": {},
+            "rev_id": 12345
+        }],
         [],
-        [{"damaging": False, "goodfaith": True, "auto_labeled": False, "autolabel": {}, "rev_id": 12345}]
+        [{
+            "damaging": False,
+            "goodfaith": True,
+            "auto_labeled": False,
+            "autolabel": {},
+            "rev_id": 12345
+        }]
     ),
     # Guess bad faith from damaging.
     (
-        [{"damaging": True, "auto_labeled": False, "autolabel": {}, "rev_id": 12345}],
+        [{
+            "damaging": True,
+            "auto_labeled": False,
+            "autolabel": {},
+            "rev_id": 12345
+        }],
         [],
-        [{"damaging": True, "goodfaith": False, "auto_labeled": False, "autolabel": {}, "rev_id": 12345}]
+        [{
+            "damaging": True,
+            "goodfaith": False,
+            "auto_labeled": False,
+            "autolabel": {},
+            "rev_id": 12345
+        }]
     ),
     # Guess not damaging from good faith.
     (
-        [{"goodfaith": True, "auto_labeled": False, "autolabel": {}, "rev_id": 12345}],
+        [{
+            "goodfaith": True,
+            "auto_labeled": False,
+            "autolabel": {},
+            "rev_id": 12345
+        }],
         [],
-        [{"damaging": False, "goodfaith": True, "auto_labeled": False, "autolabel": {}, "rev_id": 12345}]
+        [{
+            "damaging": False,
+            "goodfaith": True,
+            "auto_labeled": False,
+            "autolabel": {},
+            "rev_id": 12345
+        }]
     ),
     # Guess damaging from bad faith.
     (
-        [{"goodfaith": False, "auto_labeled": False, "autolabel": {}, "rev_id": 12345}],
+        [{
+            "goodfaith": False,
+            "auto_labeled": False,
+            "autolabel": {},
+            "rev_id": 12345
+        }],
         [],
-        [{"damaging": True, "goodfaith": False, "auto_labeled": False, "autolabel": {}, "rev_id": 12345}]
+        [{
+            "damaging": True,
+            "goodfaith": False,
+            "auto_labeled": False,
+            "autolabel": {},
+            "rev_id": 12345
+        }]
     ),
     # Merge when no human labeling was done.
     (
         [],
-        [{"rev_id": 12345, "autolabel": {"review_reason": "trusted user", "needs_review": False}, "reverted_for_damage": False}],
-        [{'auto_labeled': True, 'rev_id': 12345, 'reverted_for_damage': False,
-            'damaging': False, 'goodfaith': True, 'autolabel': {'needs_review':
-                False, 'review_reason': 'trusted user'}}]
+        [{
+            "rev_id": 12345,
+            "autolabel": {"review_reason": "trusted user", "needs_review": False},
+            "reverted_for_damage": False
+        }],
+        [{
+            'auto_labeled': True,
+            'rev_id': 12345,
+            'reverted_for_damage': False,
+            'damaging': False,
+            'goodfaith': True,
+            'autolabel': {'needs_review': False, 'review_reason': 'trusted user'}
+        }]
     ),
     # Merge when partial human labeling was done.
     (
-        [{"goodfaith": False, "auto_labeled": False, "autolabel": {}, "rev_id": 12345}],
-        [{"rev_id": 12345, "autolabel": {"review_reason": "trusted user", "needs_review": False}, "reverted_for_damage": False}],
-        [{'auto_labeled': True, 'rev_id': 12345, 'reverted_for_damage': False,
-            'damaging': True, 'goodfaith': False, 'autolabel': {'needs_review':
-                False, 'review_reason': 'trusted user'}}]
+        [{
+            "goodfaith": False,
+            "auto_labeled": False,
+            "autolabel": {},
+            "rev_id": 12345
+        }],
+        [{
+            "rev_id": 12345,
+            "autolabel": {"review_reason": "trusted user", "needs_review": False},
+            "reverted_for_damage": False
+        }],
+        [{
+            'auto_labeled': True,
+            'rev_id': 12345,
+            'reverted_for_damage': False,
+            'damaging': True,
+            'goodfaith': False,
+            'autolabel': {'needs_review': False, 'review_reason': 'trusted user'}
+        }]
     ),
     # Merge when null human labeling was done.  auto_labeled field is
     # intentionally contradictory to show that we prioritize the autolabeled
     # data for auto* fields.
     (
         [{"auto_labeled": False, "autolabel": {}, "rev_id": 12345}],
-        [{"rev_id": 12345, "autolabel": {"review_reason": "trusted user", "needs_review": False}, "reverted_for_damage": False}],
-        [{'auto_labeled': True, 'rev_id': 12345, 'reverted_for_damage': False,
-            'damaging': False, 'goodfaith': True, 'autolabel': {'needs_review':
-                False, 'review_reason': 'trusted user'}}]
+        [{
+            "rev_id": 12345,
+            "autolabel": {"review_reason": "trusted user", "needs_review": False},
+            "reverted_for_damage": False
+        }],
+        [{
+            'auto_labeled': True,
+            'rev_id': 12345,
+            'reverted_for_damage': False,
+            'damaging': False,
+            'goodfaith': True,
+            'autolabel': {'needs_review': False, 'review_reason': 'trusted user'}
+        }]
     ),
 ])
 def test_merge_labels(human, auto, expected):

--- a/editquality/utilities/tests/test_merge_labels.py
+++ b/editquality/utilities/tests/test_merge_labels.py
@@ -1,0 +1,67 @@
+import pytest
+
+from .. import merge_labels
+
+@pytest.mark.parametrize("human, auto, expected", [
+    #[{"damaging": false, "goodfaith": true, "auto_labeled": false, "autolabel": {}, "rev_id": 12345}]
+    # Discard data that needs review but has no labels.
+    (
+        [{"auto_labeled": False, "autolabel": {}, "rev_id": 12345}],
+        [],
+        []
+    ),
+    # Guess good faith from not damaging.
+    (
+        [{"damaging": False, "auto_labeled": False, "autolabel": {}, "rev_id": 12345}],
+        [],
+        [{"damaging": False, "goodfaith": True, "auto_labeled": False, "autolabel": {}, "rev_id": 12345}]
+    ),
+    # Guess bad faith from damaging.
+    (
+        [{"damaging": True, "auto_labeled": False, "autolabel": {}, "rev_id": 12345}],
+        [],
+        [{"damaging": True, "goodfaith": False, "auto_labeled": False, "autolabel": {}, "rev_id": 12345}]
+    ),
+    # Guess not damaging from good faith.
+    (
+        [{"goodfaith": True, "auto_labeled": False, "autolabel": {}, "rev_id": 12345}],
+        [],
+        [{"damaging": False, "goodfaith": True, "auto_labeled": False, "autolabel": {}, "rev_id": 12345}]
+    ),
+    # Guess damaging from bad faith.
+    (
+        [{"goodfaith": False, "auto_labeled": False, "autolabel": {}, "rev_id": 12345}],
+        [],
+        [{"damaging": True, "goodfaith": False, "auto_labeled": False, "autolabel": {}, "rev_id": 12345}]
+    ),
+    # Merge when no human labeling was done.
+    (
+        [],
+        [{"rev_id": 12345, "autolabel": {"review_reason": "trusted user", "needs_review": False}, "reverted_for_damage": False}],
+        [{'auto_labeled': True, 'rev_id': 12345, 'reverted_for_damage': False,
+            'damaging': False, 'goodfaith': True, 'autolabel': {'needs_review':
+                False, 'review_reason': 'trusted user'}}]
+    ),
+    # Merge when partial human labeling was done.
+    (
+        [{"goodfaith": False, "auto_labeled": False, "autolabel": {}, "rev_id": 12345}],
+        [{"rev_id": 12345, "autolabel": {"review_reason": "trusted user", "needs_review": False}, "reverted_for_damage": False}],
+        [{'auto_labeled': True, 'rev_id': 12345, 'reverted_for_damage': False,
+            'damaging': True, 'goodfaith': False, 'autolabel': {'needs_review':
+                False, 'review_reason': 'trusted user'}}]
+    ),
+    # Merge when null human labeling was done.  auto_labeled field is
+    # intentionally contradictory to show that we prioritize the autolabeled
+    # data for auto* fields.
+    (
+        [{"auto_labeled": False, "autolabel": {}, "rev_id": 12345}],
+        [{"rev_id": 12345, "autolabel": {"review_reason": "trusted user", "needs_review": False}, "reverted_for_damage": False}],
+        [{'auto_labeled': True, 'rev_id': 12345, 'reverted_for_damage': False,
+            'damaging': False, 'goodfaith': True, 'autolabel': {'needs_review':
+                False, 'review_reason': 'trusted user'}}]
+    ),
+])
+def test_merge_labels(human, auto, expected):
+    merged = merge_labels.run(human, auto, False)
+    merged = list(merged)
+    assert expected == merged


### PR DESCRIPTION
When autolabeled data isn't present, just clean up the wikilabels output enough that it's acceptable for model training.

Bug: T192362