### PR TITLE
Updates srwiki model with new goodfaith data.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,8 +154,8 @@ tuning_reports/arwiki.damaging.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.arwiki.damaging \
 		damaging \
-		roc_auc.labels.true \
-		--label-weight $(damaging_label_weight) \
+		$(damaging_tuning_statistic) \
+		--label-weight $(damaging_weight) \
 		--pop-rate "true=0.021427" \
 		--pop-rate "false=0.978573" \
 		--center --scale \
@@ -188,8 +188,8 @@ tuning_reports/arwiki.goodfaith.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.arwiki.goodfaith \
 		goodfaith \
-		roc_auc.labels.true \
-		--label-weight $(goodfaith_label_weight) \
+		$(goodfaith_tuning_statistic) \
+		--label-weight $(goodfaith_weight) \
 		--pop-rate "true=0.993861" \
 		--pop-rate "false=0.0061390000000000056" \
 		--center --scale \
@@ -289,8 +289,8 @@ tuning_reports/bnwiki.reverted.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.bnwiki.reverted \
 		reverted_for_damage \
-		roc_auc.labels.true \
-		--label-weight $(reverted_label_weight) \
+		$(reverted_tuning_statistic) \
+		--label-weight $(reverted_weight) \
 		--pop-rate "true=0.021554310862" \
 		--pop-rate "false=0.978445689138" \
 		--center --scale \
@@ -381,8 +381,8 @@ tuning_reports/bswiki.damaging.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.bswiki.damaging \
 		damaging \
-		roc_auc.labels.true \
-		--label-weight $(damaging_label_weight) \
+		$(damaging_tuning_statistic) \
+		--label-weight $(damaging_weight) \
 		--pop-rate "true=0.028101164191087918" \
 		--pop-rate "false=0.9718988358089121" \
 		--center --scale \
@@ -415,8 +415,8 @@ tuning_reports/bswiki.goodfaith.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.bswiki.goodfaith \
 		goodfaith \
-		roc_auc.labels.true \
-		--label-weight $(goodfaith_label_weight) \
+		$(goodfaith_tuning_statistic) \
+		--label-weight $(goodfaith_weight) \
 		--pop-rate "true=0.9774939783219591" \
 		--pop-rate "false=0.022506021678040944" \
 		--center --scale \
@@ -491,8 +491,8 @@ tuning_reports/cawiki.damaging.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.cawiki.damaging \
 		damaging \
-		roc_auc.labels.true \
-		--label-weight $(damaging_label_weight) \
+		$(damaging_tuning_statistic) \
+		--label-weight $(damaging_weight) \
 		--pop-rate "true=0.019000475011875295" \
 		--pop-rate "false=0.9809995249881247" \
 		--center --scale \
@@ -525,8 +525,8 @@ tuning_reports/cawiki.goodfaith.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.cawiki.goodfaith \
 		goodfaith \
-		roc_auc.labels.true \
-		--label-weight $(goodfaith_label_weight) \
+		$(goodfaith_tuning_statistic) \
+		--label-weight $(goodfaith_weight) \
 		--pop-rate "true=0.9854996374909373" \
 		--pop-rate "false=0.014500362509062725" \
 		--center --scale \
@@ -609,8 +609,8 @@ tuning_reports/cswiki.damaging.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.cswiki.damaging \
 		damaging \
-		roc_auc.labels.true \
-		--label-weight $(damaging_label_weight) \
+		$(damaging_tuning_statistic) \
+		--label-weight $(damaging_weight) \
 		--pop-rate "true=0.0445968266680014" \
 		--pop-rate "false=0.9554031733319986" \
 		--center --scale \
@@ -643,8 +643,8 @@ tuning_reports/cswiki.goodfaith.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.cswiki.goodfaith \
 		goodfaith \
-		roc_auc.labels.true \
-		--label-weight $(goodfaith_label_weight) \
+		$(goodfaith_tuning_statistic) \
+		--label-weight $(goodfaith_weight) \
 		--pop-rate "true=0.977526402722859" \
 		--pop-rate "false=0.022473597277141044" \
 		--center --scale \
@@ -718,8 +718,8 @@ tuning_reports/dewiki.damaging.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.dewiki.damaging \
 		damaging \
-		roc_auc.labels.true \
-		--label-weight $(damaging_label_weight) \
+		$(damaging_tuning_statistic) \
+		--label-weight $(damaging_weight) \
 		--pop-rate "true=0.029975955116216937" \
 		--pop-rate "false=0.970024044883783" \
 		--center --scale \
@@ -752,8 +752,8 @@ tuning_reports/dewiki.goodfaith.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.dewiki.goodfaith \
 		goodfaith \
-		roc_auc.labels.true \
-		--label-weight $(goodfaith_label_weight) \
+		$(goodfaith_tuning_statistic) \
+		--label-weight $(goodfaith_weight) \
 		--pop-rate "true=0.9806572268234037" \
 		--pop-rate "false=0.019342773176596273" \
 		--center --scale \
@@ -818,8 +818,8 @@ tuning_reports/elwiki.reverted.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.elwiki.reverted \
 		reverted_for_damage \
-		roc_auc.labels.true \
-		--label-weight $(reverted_label_weight) \
+		$(reverted_tuning_statistic) \
+		--label-weight $(reverted_weight) \
 		--pop-rate "true=0.05170687756532186" \
 		--pop-rate "false=0.9482931224346781" \
 		--center --scale \
@@ -878,8 +878,8 @@ tuning_reports/enwiki.damaging.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.enwiki.damaging \
 		damaging \
-		roc_auc.labels.true \
-		--label-weight $(damaging_label_weight) \
+		$(damaging_tuning_statistic) \
+		--label-weight $(damaging_weight) \
 		--pop-rate "true=0.034163555464634586" \
 		--pop-rate "false=0.9658364445353654" \
 		--center --scale \
@@ -912,8 +912,8 @@ tuning_reports/enwiki.goodfaith.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.enwiki.goodfaith \
 		goodfaith \
-		roc_auc.labels.true \
-		--label-weight $(goodfaith_label_weight) \
+		$(goodfaith_tuning_statistic) \
+		--label-weight $(goodfaith_weight) \
 		--pop-rate "true=0.9671661637600368" \
 		--pop-rate "false=0.032833836239963166" \
 		--center --scale \
@@ -977,8 +977,8 @@ tuning_reports/enwiktionary.reverted.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.enwiktionary.reverted \
 		reverted_for_damage \
-		roc_auc.labels.true \
-		--label-weight $(reverted_label_weight) \
+		$(reverted_tuning_statistic) \
+		--label-weight $(reverted_weight) \
 		--pop-rate "true=0.004778273117085203" \
 		--pop-rate "false=0.9952217268829148" \
 		--center --scale \
@@ -1050,8 +1050,8 @@ tuning_reports/eswiki.damaging.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.eswiki.damaging \
 		damaging \
-		roc_auc.labels.true \
-		--label-weight $(damaging_label_weight) \
+		$(damaging_tuning_statistic) \
+		--label-weight $(damaging_weight) \
 		--pop-rate "true=0.11036013315847877" \
 		--pop-rate "false=0.8896398668415212" \
 		--center --scale \
@@ -1084,8 +1084,8 @@ tuning_reports/eswiki.goodfaith.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.eswiki.goodfaith \
 		goodfaith \
-		roc_auc.labels.true \
-		--label-weight $(goodfaith_label_weight) \
+		$(goodfaith_tuning_statistic) \
+		--label-weight $(goodfaith_weight) \
 		--pop-rate "true=0.11036013315847877" \
 		--pop-rate "false=0.8896398668415212" \
 		--center --scale \
@@ -1159,8 +1159,8 @@ tuning_reports/eswikibooks.damaging.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.eswikibooks.damaging \
 		damaging \
-		roc_auc.labels.true \
-		--label-weight $(damaging_label_weight) \
+		$(damaging_tuning_statistic) \
+		--label-weight $(damaging_weight) \
 		--pop-rate "true=0.1126671580499105" \
 		--pop-rate "false=0.8873328419500895" \
 		--center --scale \
@@ -1193,8 +1193,8 @@ tuning_reports/eswikibooks.goodfaith.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.eswikibooks.goodfaith \
 		goodfaith \
-		roc_auc.labels.true \
-		--label-weight $(goodfaith_label_weight) \
+		$(goodfaith_tuning_statistic) \
+		--label-weight $(goodfaith_weight) \
 		--pop-rate "true=0.9139393939393939" \
 		--pop-rate "false=0.08606060606060606" \
 		--center --scale \
@@ -1269,8 +1269,8 @@ tuning_reports/eswikiquote.damaging.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.eswikiquote.damaging \
 		damaging \
-		roc_auc.labels.true \
-		--label-weight $(damaging_label_weight) \
+		$(damaging_tuning_statistic) \
+		--label-weight $(damaging_weight) \
 		--pop-rate "true=0.08707101597009854" \
 		--pop-rate "false=0.9129289840299014" \
 		--center --scale \
@@ -1303,8 +1303,8 @@ tuning_reports/eswikiquote.goodfaith.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.eswikiquote.goodfaith \
 		goodfaith \
-		roc_auc.labels.true \
-		--label-weight $(goodfaith_label_weight) \
+		$(goodfaith_tuning_statistic) \
+		--label-weight $(goodfaith_weight) \
 		--pop-rate "true=0.9356099218484539" \
 		--pop-rate "false=0.06439007815154607" \
 		--center --scale \
@@ -1378,8 +1378,8 @@ tuning_reports/etwiki.damaging.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.etwiki.damaging \
 		damaging \
-		roc_auc.labels.true \
-		--label-weight $(damaging_label_weight) \
+		$(damaging_tuning_statistic) \
+		--label-weight $(damaging_weight) \
 		--pop-rate "true=0.026158257457618593" \
 		--pop-rate "false=0.9738417425423814" \
 		--center --scale \
@@ -1412,8 +1412,8 @@ tuning_reports/etwiki.goodfaith.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.etwiki.goodfaith \
 		goodfaith \
-		roc_auc.labels.true \
-		--label-weight $(goodfaith_label_weight) \
+		$(goodfaith_tuning_statistic) \
+		--label-weight $(goodfaith_weight) \
 		--pop-rate "true=0.9841038281603702" \
 		--pop-rate "false=0.01589617183962977" \
 		--center --scale \
@@ -1500,8 +1500,8 @@ tuning_reports/fawiki.damaging.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.fawiki.damaging \
 		damaging \
-		roc_auc.labels.true \
-		--label-weight $(damaging_label_weight) \
+		$(damaging_tuning_statistic) \
+		--label-weight $(damaging_weight) \
 		--pop-rate "true=0.0297029702970297" \
 		--pop-rate "false=0.9702970297029703" \
 		--center --scale \
@@ -1534,8 +1534,8 @@ tuning_reports/fawiki.goodfaith.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.fawiki.goodfaith \
 		goodfaith \
-		roc_auc.labels.true \
-		--label-weight $(goodfaith_label_weight) \
+		$(goodfaith_tuning_statistic) \
+		--label-weight $(goodfaith_weight) \
 		--pop-rate "true=0.9834641681438339" \
 		--pop-rate "false=0.01653583185616614" \
 		--center --scale \
@@ -1618,8 +1618,8 @@ tuning_reports/frwiki.damaging.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.frwiki.damaging \
 		damaging \
-		roc_auc.labels.true \
-		--label-weight $(damaging_label_weight) \
+		$(damaging_tuning_statistic) \
+		--label-weight $(damaging_weight) \
 		--pop-rate "true=0.028751753155680224" \
 		--pop-rate "false=0.9712482468443198" \
 		--center --scale \
@@ -1652,8 +1652,8 @@ tuning_reports/frwiki.goodfaith.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.frwiki.goodfaith \
 		goodfaith \
-		roc_auc.labels.true \
-		--label-weight $(goodfaith_label_weight) \
+		$(goodfaith_tuning_statistic) \
+		--label-weight $(goodfaith_weight) \
 		--pop-rate "true=0.9786115007012622" \
 		--pop-rate "false=0.021388499298737762" \
 		--center --scale \
@@ -1749,8 +1749,8 @@ tuning_reports/hewiki.damaging.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.hewiki.damaging \
 		damaging \
-		roc_auc.labels.true \
-		--label-weight $(damaging_label_weight) \
+		$(damaging_tuning_statistic) \
+		--label-weight $(damaging_weight) \
 		--pop-rate "true=0.046281731975314835" \
 		--pop-rate "false=0.9537182680246852" \
 		--center --scale \
@@ -1783,8 +1783,8 @@ tuning_reports/hewiki.goodfaith.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.hewiki.goodfaith \
 		goodfaith \
-		roc_auc.labels.true \
-		--label-weight $(goodfaith_label_weight) \
+		$(goodfaith_tuning_statistic) \
+		--label-weight $(goodfaith_weight) \
 		--pop-rate "true=0.9718244945060459" \
 		--pop-rate "false=0.02817550549395409" \
 		--center --scale \
@@ -1849,8 +1849,8 @@ tuning_reports/hrwiki.reverted.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.hrwiki.reverted \
 		reverted_for_damage \
-		roc_auc.labels.true \
-		--label-weight $(reverted_label_weight) \
+		$(reverted_tuning_statistic) \
+		--label-weight $(reverted_weight) \
 		--pop-rate "true=0.07927353670258512" \
 		--pop-rate "false=0.9207264632974149" \
 		--center --scale \
@@ -1931,8 +1931,8 @@ tuning_reports/huwiki.damaging.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.huwiki.damaging \
 		damaging \
-		roc_auc.labels.true \
-		--label-weight $(damaging_label_weight) \
+		$(damaging_tuning_statistic) \
+		--label-weight $(damaging_weight) \
 		--pop-rate "true=0.01093805131" \
 		--pop-rate "false=0.98906194869" \
 		--center --scale \
@@ -1965,8 +1965,8 @@ tuning_reports/huwiki.goodfaith.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.huwiki.goodfaith \
 		goodfaith \
-		roc_auc.labels.true \
-		--label-weight $(goodfaith_label_weight) \
+		$(goodfaith_tuning_statistic) \
+		--label-weight $(goodfaith_weight) \
 		--pop-rate "true=0.99221230908" \
 		--pop-rate "false=0.007787690919999979" \
 		--center --scale \
@@ -2030,8 +2030,8 @@ tuning_reports/idwiki.reverted.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.idwiki.reverted \
 		reverted_for_damage \
-		roc_auc.labels.true \
-		--label-weight $(reverted_label_weight) \
+		$(reverted_tuning_statistic) \
+		--label-weight $(reverted_weight) \
 		--pop-rate "true=0.02272613605673532" \
 		--pop-rate "false=0.9772738639432647" \
 		--center --scale \
@@ -2094,8 +2094,8 @@ tuning_reports/iswiki.reverted.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.iswiki.reverted \
 		reverted_for_damage \
-		roc_auc.labels.true \
-		--label-weight $(reverted_label_weight) \
+		$(reverted_tuning_statistic) \
+		--label-weight $(reverted_weight) \
 		--pop-rate "true=0.08115405770288514" \
 		--pop-rate "false=0.9188459422971149" \
 		--center --scale \
@@ -2167,8 +2167,8 @@ tuning_reports/itwiki.damaging.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.itwiki.damaging \
 		damaging \
-		roc_auc.labels.true \
-		--label-weight $(damaging_label_weight) \
+		$(damaging_tuning_statistic) \
+		--label-weight $(damaging_weight) \
 		--pop-rate "true=0.038665452792802445" \
 		--pop-rate "false=0.9613345472071976" \
 		--center --scale \
@@ -2201,8 +2201,8 @@ tuning_reports/itwiki.goodfaith.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.itwiki.goodfaith \
 		goodfaith \
-		roc_auc.labels.true \
-		--label-weight $(goodfaith_label_weight) \
+		$(goodfaith_tuning_statistic) \
+		--label-weight $(goodfaith_weight) \
 		--pop-rate "true=0.9807743801210304" \
 		--pop-rate "false=0.019225619878969646" \
 		--center --scale \
@@ -2267,8 +2267,8 @@ tuning_reports/jawiki.reverted.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.jawiki.reverted \
 		reverted_for_damage \
-		roc_auc.labels.true \
-		--label-weight $(reverted_label_weight) \
+		$(reverted_tuning_statistic) \
+		--label-weight $(reverted_weight) \
 		--pop-rate "true=0.03256945140908635" \
 		--pop-rate "false=0.9674305485909136" \
 		--center --scale \
@@ -2341,8 +2341,8 @@ tuning_reports/kowiki.damaging.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.kowiki.damaging \
 		damaging \
-		roc_auc.labels.true \
-		--label-weight $(damaging_label_weight) \
+		$(damaging_tuning_statistic) \
+		--label-weight $(damaging_weight) \
 		--pop-rate "true=0.038665452792802445" \
 		--pop-rate "false=0.9613345472071976" \
 		--center --scale \
@@ -2375,8 +2375,8 @@ tuning_reports/kowiki.goodfaith.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.kowiki.goodfaith \
 		goodfaith \
-		roc_auc.labels.true \
-		--label-weight $(goodfaith_label_weight) \
+		$(goodfaith_tuning_statistic) \
+		--label-weight $(goodfaith_weight) \
 		--pop-rate "true=0.9807743801210304" \
 		--pop-rate "false=0.019225619878969646" \
 		--center --scale \
@@ -2451,8 +2451,8 @@ tuning_reports/lvwiki.damaging.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.lvwiki.damaging \
 		damaging \
-		roc_auc.labels.true \
-		--label-weight $(damaging_label_weight) \
+		$(damaging_tuning_statistic) \
+		--label-weight $(damaging_weight) \
 		--pop-rate "true=0.0293" \
 		--pop-rate "false=0.9707" \
 		--center --scale \
@@ -2485,8 +2485,8 @@ tuning_reports/lvwiki.goodfaith.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.lvwiki.goodfaith \
 		goodfaith \
-		roc_auc.labels.true \
-		--label-weight $(goodfaith_label_weight) \
+		$(goodfaith_tuning_statistic) \
+		--label-weight $(goodfaith_weight) \
 		--pop-rate "true=0.978" \
 		--pop-rate "false=0.02200000000000002" \
 		--center --scale \
@@ -2560,8 +2560,8 @@ tuning_reports/nlwiki.damaging.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.nlwiki.damaging \
 		damaging \
-		roc_auc.labels.true \
-		--label-weight $(damaging_label_weight) \
+		$(damaging_tuning_statistic) \
+		--label-weight $(damaging_weight) \
 		--pop-rate "true=0.05068086413432989" \
 		--pop-rate "false=0.9493191358656701" \
 		--center --scale \
@@ -2594,8 +2594,8 @@ tuning_reports/nlwiki.goodfaith.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.nlwiki.goodfaith \
 		goodfaith \
-		roc_auc.labels.true \
-		--label-weight $(goodfaith_label_weight) \
+		$(goodfaith_tuning_statistic) \
+		--label-weight $(goodfaith_weight) \
 		--pop-rate "true=0.9646257806900789" \
 		--pop-rate "false=0.03537421930992113" \
 		--center --scale \
@@ -2672,8 +2672,8 @@ tuning_reports/nowiki.reverted.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.nowiki.reverted \
 		reverted_for_damage \
-		roc_auc.labels.true \
-		--label-weight $(reverted_label_weight) \
+		$(reverted_tuning_statistic) \
+		--label-weight $(reverted_weight) \
 		--pop-rate "true=0.019061539539679838" \
 		--pop-rate "false=0.9809384604603202" \
 		--center --scale \
@@ -2732,8 +2732,8 @@ tuning_reports/ptwiki.damaging.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.ptwiki.damaging \
 		damaging \
-		roc_auc.labels.true \
-		--label-weight $(damaging_label_weight) \
+		$(damaging_tuning_statistic) \
+		--label-weight $(damaging_weight) \
 		--pop-rate "true=0.06896029864299047" \
 		--pop-rate "false=0.9310397013570095" \
 		--center --scale \
@@ -2766,8 +2766,8 @@ tuning_reports/ptwiki.goodfaith.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.ptwiki.goodfaith \
 		goodfaith \
-		roc_auc.labels.true \
-		--label-weight $(goodfaith_label_weight) \
+		$(goodfaith_tuning_statistic) \
+		--label-weight $(goodfaith_weight) \
 		--pop-rate "true=0.9397669373959542" \
 		--pop-rate "false=0.06023306260404582" \
 		--center --scale \
@@ -2841,8 +2841,8 @@ tuning_reports/rowiki.damaging.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.rowiki.damaging \
 		damaging \
-		roc_auc.labels.true \
-		--label-weight $(damaging_label_weight) \
+		$(damaging_tuning_statistic) \
+		--label-weight $(damaging_weight) \
 		--pop-rate "true=0.04956982793117247" \
 		--pop-rate "false=0.9504301720688275" \
 		--center --scale \
@@ -2875,8 +2875,8 @@ tuning_reports/rowiki.goodfaith.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.rowiki.goodfaith \
 		goodfaith \
-		roc_auc.labels.true \
-		--label-weight $(goodfaith_label_weight) \
+		$(goodfaith_tuning_statistic) \
+		--label-weight $(goodfaith_weight) \
 		--pop-rate "true=0.9699379751900761" \
 		--pop-rate "false=0.030062024809923926" \
 		--center --scale \
@@ -2963,8 +2963,8 @@ tuning_reports/ruwiki.damaging.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.ruwiki.damaging \
 		damaging \
-		roc_auc.labels.true \
-		--label-weight $(damaging_label_weight) \
+		$(damaging_tuning_statistic) \
+		--label-weight $(damaging_weight) \
 		--pop-rate "true=0.053479185657854755" \
 		--pop-rate "false=0.9465208143421453" \
 		--center --scale \
@@ -2997,8 +2997,8 @@ tuning_reports/ruwiki.goodfaith.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.ruwiki.goodfaith \
 		goodfaith \
-		roc_auc.labels.true \
-		--label-weight $(goodfaith_label_weight) \
+		$(goodfaith_tuning_statistic) \
+		--label-weight $(goodfaith_weight) \
 		--pop-rate "true=0.9713866099463182" \
 		--pop-rate "false=0.028613390053681798" \
 		--center --scale \
@@ -3073,8 +3073,8 @@ tuning_reports/sqwiki.damaging.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.sqwiki.damaging \
 		damaging \
-		roc_auc.labels.true \
-		--label-weight $(damaging_label_weight) \
+		$(damaging_tuning_statistic) \
+		--label-weight $(damaging_weight) \
 		--pop-rate "true=0.0287028702870287" \
 		--pop-rate "false=0.9712971297129713" \
 		--center --scale \
@@ -3107,8 +3107,8 @@ tuning_reports/sqwiki.goodfaith.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.sqwiki.goodfaith \
 		goodfaith \
-		roc_auc.labels.true \
-		--label-weight $(goodfaith_label_weight) \
+		$(goodfaith_tuning_statistic) \
+		--label-weight $(goodfaith_weight) \
 		--pop-rate "true=0.9763476347634763" \
 		--pop-rate "false=0.023652365236523698" \
 		--center --scale \
@@ -3144,6 +3144,10 @@ sqwiki_tuning_reports: \
 
 
 ############################# Serbian Wikipedia ################################
+datasets/srwiki.badfaith_relabeling_revisions.500_2017.json:
+	./utility fetch_labels \
+		https://labels.wmflabs.org/campaigns/srwiki/89/ > $@
+
 datasets/srwiki.human_labeled_revisions.5k_2017.json:
 	./utility fetch_labels \
 		https://labels.wmflabs.org/campaigns/srwiki/62/ > $@
@@ -3161,6 +3165,11 @@ datasets/srwiki.autolabeled_revisions.120k_2017.json: \
 		--verbose > $@
 
 datasets/srwiki.labeled_revisions.120k_2017.json: \
+		datasets/srwiki.badfaith_relabeling_revisions.500_2017.json \
+		datasets/srwiki.original_labeled_revisions.120k_2017.json
+	./utility merge_labels $^ > $@
+
+datasets/srwiki.original_labeled_revisions.120k_2017.json: \
 		datasets/srwiki.human_labeled_revisions.5k_2017.json \
 		datasets/srwiki.autolabeled_revisions.120k_2017.json
 	./utility merge_labels $^ > $@
@@ -3182,8 +3191,8 @@ tuning_reports/srwiki.damaging.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.srwiki.damaging \
 		damaging \
-		roc_auc.labels.true \
-		--label-weight $(damaging_label_weight) \
+		$(damaging_tuning_statistic) \
+		--label-weight $(damaging_weight) \
 		--pop-rate "true=0.0056294177044766075" \
 		--pop-rate "false=0.9943705822955234" \
 		--center --scale \
@@ -3197,7 +3206,7 @@ models/srwiki.damaging.gradient_boosting.model: \
 		revscoring.scoring.models.GradientBoosting \
 		editquality.feature_lists.srwiki.damaging \
 		damaging \
-		--version=$(damaging_major_minor).0 \
+		--version=$(damaging_major_minor).1 \
 		-p 'learning_rate=0.01' \
 		-p 'max_depth=7' \
 		-p 'max_features="log2"' \
@@ -3216,8 +3225,8 @@ tuning_reports/srwiki.goodfaith.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.srwiki.goodfaith \
 		goodfaith \
-		roc_auc.labels.true \
-		--label-weight $(goodfaith_label_weight) \
+		$(goodfaith_tuning_statistic) \
+		--label-weight $(goodfaith_weight) \
 		--pop-rate "true=0.9961881521373275" \
 		--pop-rate "false=0.003811847862672524" \
 		--center --scale \
@@ -3231,11 +3240,11 @@ models/srwiki.goodfaith.gradient_boosting.model: \
 		revscoring.scoring.models.GradientBoosting \
 		editquality.feature_lists.srwiki.goodfaith \
 		goodfaith \
-		--version=$(goodfaith_major_minor).0 \
-		-p 'learning_rate=0.1' \
-		-p 'max_depth=7' \
+		--version=$(goodfaith_major_minor).1 \
+		-p 'learning_rate=0.01' \
+		-p 'max_depth=5' \
 		-p 'max_features="log2"' \
-		-p 'n_estimators=700' \
+		-p 'n_estimators=500' \
 		--label-weight $(goodfaith_weight) \
 		--pop-rate "true=0.9961881521373275" \
 		--pop-rate "false=0.003811847862672524" \
@@ -3300,8 +3309,8 @@ tuning_reports/svwiki.damaging.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.svwiki.damaging \
 		damaging \
-		roc_auc.labels.true \
-		--label-weight $(damaging_label_weight) \
+		$(damaging_tuning_statistic) \
+		--label-weight $(damaging_weight) \
 		--pop-rate "true=0.025209073272463033" \
 		--pop-rate "false=0.974790926727537" \
 		--center --scale \
@@ -3334,8 +3343,8 @@ tuning_reports/svwiki.goodfaith.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.svwiki.goodfaith \
 		goodfaith \
-		roc_auc.labels.true \
-		--label-weight $(goodfaith_label_weight) \
+		$(goodfaith_tuning_statistic) \
+		--label-weight $(goodfaith_weight) \
 		--pop-rate "true=0.9822912868686937" \
 		--pop-rate "false=0.017708713131306286" \
 		--center --scale \
@@ -3400,8 +3409,8 @@ tuning_reports/tawiki.reverted.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.tawiki.reverted \
 		reverted_for_damage \
-		roc_auc.labels.true \
-		--label-weight $(reverted_label_weight) \
+		$(reverted_tuning_statistic) \
+		--label-weight $(reverted_weight) \
 		--pop-rate "true=0.015904172328753335" \
 		--pop-rate "false=0.9840958276712467" \
 		--center --scale \
@@ -3463,8 +3472,8 @@ tuning_reports/trwiki.damaging.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.trwiki.damaging \
 		damaging \
-		roc_auc.labels.true \
-		--label-weight $(damaging_label_weight) \
+		$(damaging_tuning_statistic) \
+		--label-weight $(damaging_weight) \
 		--pop-rate "true=0.0495014425266994" \
 		--pop-rate "false=0.9504985574733006" \
 		--center --scale \
@@ -3497,8 +3506,8 @@ tuning_reports/trwiki.goodfaith.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.trwiki.goodfaith \
 		goodfaith \
-		roc_auc.labels.true \
-		--label-weight $(goodfaith_label_weight) \
+		$(goodfaith_tuning_statistic) \
+		--label-weight $(goodfaith_weight) \
 		--pop-rate "true=0.9538897605911829" \
 		--pop-rate "false=0.04611023940881709" \
 		--center --scale \
@@ -3562,8 +3571,8 @@ tuning_reports/ukwiki.reverted.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.ukwiki.reverted \
 		reverted_for_damage \
-		roc_auc.labels.true \
-		--label-weight $(reverted_label_weight) \
+		$(reverted_tuning_statistic) \
+		--label-weight $(reverted_weight) \
 		--pop-rate "true=0.021877665713282153" \
 		--pop-rate "false=0.9781223342867178" \
 		--center --scale \
@@ -3660,8 +3669,8 @@ tuning_reports/viwiki.reverted.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.viwiki.reverted \
 		reverted_for_damage \
-		roc_auc.labels.true \
-		--label-weight $(reverted_label_weight) \
+		$(reverted_tuning_statistic) \
+		--label-weight $(reverted_weight) \
 		--pop-rate "true=0.019211042993949594" \
 		--pop-rate "false=0.9807889570060504" \
 		--center --scale \

--- a/Makefile.manual
+++ b/Makefile.manual
@@ -12,6 +12,10 @@ reverted_weight = 'true=10'
 damaging_weight = 'true=10'
 goodfaith_weight = 'false=10'
 
+reverted_tuning_statistic = roc_auc.labels.true
+damaging_tuning_statistic = roc_auc.labels.true
+goodfaith_tuning_statistic = roc_auc.labels.false
+
 max_extractors = 4
 
 

--- a/config/wikis/srwiki.yaml
+++ b/config/wikis/srwiki.yaml
@@ -7,6 +7,8 @@ external_samples:
     quarry_url: https://quarry.wmflabs.org/run/211097/output/0/json-lines?download=true
   human_labeled_revisions.5k_2017:
     labeling_campaign: https://labels.wmflabs.org/campaigns/srwiki/62/
+  badfaith_relabeling_revisions.500_2017:
+    labeling_campaign: https://labels.wmflabs.org/campaigns/srwiki/89/
 
 autolabeled_samples:
   trusted_edits: 1000
@@ -21,9 +23,12 @@ autolabeled_samples:
     autolabeled_revisions.120k_2017: sampled_revisions.120k_2017
 
 merged_samples:
-  labeled_revisions.120k_2017:
+  original_labeled_revisions.120k_2017:
     - human_labeled_revisions.5k_2017
     - autolabeled_revisions.120k_2017
+  labeled_revisions.120k_2017:
+    - badfaith_relabeling_revisions.500_2017
+    - original_labeled_revisions.120k_2017
 
 extracted_samples:
   labeled_revisions.w_cache.120k_2017:
@@ -40,6 +45,7 @@ models:
     tune: true
     cv_train:
       algorithm: GradientBoosting
+      build_number: 1
       parameters:
         learning_rate: 0.01
         max_depth: 7
@@ -52,8 +58,9 @@ models:
     tune: true
     cv_train:
       algorithm: GradientBoosting
+      build_number: 1
       parameters:
-        learning_rate: 0.1
-        max_depth: 7
+        learning_rate: 0.01
+        max_depth: 5
         max_features: log2
-        n_estimators: 700
+        n_estimators: 500

--- a/model_info/srwiki.damaging.md
+++ b/model_info/srwiki.damaging.md
@@ -1,12 +1,12 @@
 Model Information:
 	 - type: GradientBoosting
-	 - version: 0.5.0
-	 - params: {'scale': True, 'presort': 'auto', 'warm_start': False, 'max_depth': 7, 'verbose': 0, 'center': True, 'labels': [True, False], 'learning_rate': 0.01, 'subsample': 1.0, 'label_weights': OrderedDict([(True, 10)]), 'min_samples_split': 2, 'max_features': 'log2', 'min_impurity_decrease': 0.0, 'min_impurity_split': None, 'n_estimators': 700, 'min_samples_leaf': 1, 'multilabel': False, 'min_weight_fraction_leaf': 0.0, 'criterion': 'friedman_mse', 'init': None, 'random_state': None, 'max_leaf_nodes': None, 'population_rates': None, 'loss': 'deviance'}
+	 - version: 0.5.1
+	 - params: {'loss': 'deviance', 'presort': 'auto', 'center': True, 'max_leaf_nodes': None, 'n_estimators': 700, 'warm_start': False, 'max_features': 'log2', 'init': None, 'scale': True, 'random_state': None, 'min_impurity_decrease': 0.0, 'subsample': 1.0, 'min_weight_fraction_leaf': 0.0, 'criterion': 'friedman_mse', 'labels': [True, False], 'min_samples_leaf': 1, 'min_impurity_split': None, 'learning_rate': 0.01, 'multilabel': False, 'label_weights': OrderedDict([(True, 10)]), 'population_rates': None, 'verbose': 0, 'min_samples_split': 2, 'max_depth': 7}
 	Environment:
-	 - revscoring_version: '2.3.4'
-	 - platform: 'Linux-4.9.0-8-amd64-x86_64-with-debian-9.5'
+	 - revscoring_version: '2.4.0'
+	 - platform: 'Linux-4.9.0-9-amd64-x86_64-with-debian-9.9'
 	 - machine: 'x86_64'
-	 - version: '#1 SMP Debian 4.9.110-3+deb9u6 (2018-10-08)'
+	 - version: '#1 SMP Debian 4.9.168-1+deb9u2 (2019-05-13)'
 	 - system: 'Linux'
 	 - processor: ''
 	 - python_build: ('default', 'Sep 27 2018 17:25:39')
@@ -15,67 +15,67 @@ Model Information:
 	 - python_implementation: 'CPython'
 	 - python_revision: ''
 	 - python_version: '3.5.3'
-	 - release: '4.9.0-8-amd64'
+	 - release: '4.9.0-9-amd64'
 	
 	Statistics:
-	counts (n=119890):
+	counts (n=119869):
 		label         n         ~True    ~False
 		-------  ------  ---  -------  --------
-		True        669  -->      359       310
-		False    119221  -->      787    118434
+		True        419  -->      193       226
+		False    119450  -->      252    119198
 	rates:
 		              True    False
 		----------  ------  -------
-		sample       0.006    0.994
+		sample       0.003    0.997
 		population   0.006    0.994
-	match_rate (micro=0.985, macro=0.5):
+	match_rate (micro=0.99, macro=0.5):
 		  False    True
 		-------  ------
-		   0.99    0.01
-	filter_rate (micro=0.015, macro=0.5):
+		  0.995   0.005
+	filter_rate (micro=0.01, macro=0.5):
 		  False    True
 		-------  ------
-		   0.01    0.99
-	recall (micro=0.991, macro=0.765):
+		  0.005   0.995
+	recall (micro=0.995, macro=0.729):
 		  False    True
 		-------  ------
-		  0.993   0.537
-	!recall (micro=0.539, macro=0.765):
+		  0.998   0.461
+	!recall (micro=0.464, macro=0.729):
 		  False    True
 		-------  ------
-		  0.537   0.993
-	precision (micro=0.994, macro=0.656):
+		  0.461   0.998
+	precision (micro=0.994, macro=0.775):
 		  False    True
 		-------  ------
-		  0.997   0.315
-	!precision (micro=0.319, macro=0.656):
+		  0.997   0.553
+	!precision (micro=0.555, macro=0.775):
 		  False    True
 		-------  ------
-		  0.315   0.997
-	f1 (micro=0.992, macro=0.696):
+		  0.553   0.997
+	f1 (micro=0.995, macro=0.75):
 		  False    True
 		-------  ------
-		  0.995   0.397
-	!f1 (micro=0.4, macro=0.696):
+		  0.997   0.503
+	!f1 (micro=0.505, macro=0.75):
 		  False    True
 		-------  ------
-		  0.397   0.995
-	accuracy (micro=0.991, macro=0.991):
+		  0.503   0.997
+	accuracy (micro=0.995, macro=0.995):
 		  False    True
 		-------  ------
-		  0.991   0.991
-	fpr (micro=0.461, macro=0.235):
+		  0.995   0.995
+	fpr (micro=0.536, macro=0.271):
 		  False    True
 		-------  ------
-		  0.463   0.007
-	roc_auc (micro=0.986, macro=0.984):
+		  0.539   0.002
+	roc_auc (micro=0.987, macro=0.986):
 		  False    True
 		-------  ------
-		  0.986   0.982
-	pr_auc (micro=0.997, macro=0.711):
+		  0.987   0.984
+	pr_auc (micro=0.997, macro=0.75):
 		  False    True
 		-------  ------
-		      1   0.423
+		      1     0.5
 	
-	 - score_schema: {'properties': {'probability': {'description': 'A mapping of probabilities onto each of the potential output labels', 'properties': {'false': {'type': 'number'}, 'true': {'type': 'number'}}, 'type': 'object'}, 'prediction': {'description': 'The most likely label predicted by the estimator', 'type': 'boolean'}}, 'title': 'Scikit learn-based classifier score with probability', 'type': 'object'}
+	 - score_schema: {'title': 'Scikit learn-based classifier score with probability', 'type': 'object', 'properties': {'prediction': {'type': 'boolean', 'description': 'The most likely label predicted by the estimator'}, 'probability': {'type': 'object', 'properties': {'false': {'type': 'number'}, 'true': {'type': 'number'}}, 'description': 'A mapping of probabilities onto each of the potential output labels'}}}
 

--- a/model_info/srwiki.goodfaith.md
+++ b/model_info/srwiki.goodfaith.md
@@ -1,12 +1,12 @@
 Model Information:
 	 - type: GradientBoosting
-	 - version: 0.5.0
-	 - params: {'max_features': 'log2', 'labels': [True, False], 'label_weights': OrderedDict([(False, 10)]), 'max_depth': 7, 'min_samples_leaf': 1, 'min_samples_split': 2, 'learning_rate': 0.1, 'presort': 'auto', 'subsample': 1.0, 'min_weight_fraction_leaf': 0.0, 'criterion': 'friedman_mse', 'scale': True, 'multilabel': False, 'verbose': 0, 'max_leaf_nodes': None, 'loss': 'deviance', 'random_state': None, 'population_rates': None, 'min_impurity_decrease': 0.0, 'n_estimators': 700, 'warm_start': False, 'init': None, 'center': True, 'min_impurity_split': None}
+	 - version: 0.5.1
+	 - params: {'loss': 'deviance', 'learning_rate': 0.01, 'center': True, 'scale': True, 'random_state': None, 'multilabel': False, 'criterion': 'friedman_mse', 'max_leaf_nodes': None, 'init': None, 'max_features': 'log2', 'max_depth': 5, 'population_rates': None, 'label_weights': OrderedDict([(False, 10)]), 'warm_start': False, 'labels': [True, False], 'min_impurity_split': None, 'verbose': 0, 'min_samples_leaf': 1, 'subsample': 1.0, 'min_impurity_decrease': 0.0, 'min_weight_fraction_leaf': 0.0, 'n_estimators': 500, 'min_samples_split': 2, 'presort': 'auto'}
 	Environment:
-	 - revscoring_version: '2.3.4'
-	 - platform: 'Linux-4.9.0-8-amd64-x86_64-with-debian-9.5'
+	 - revscoring_version: '2.4.0'
+	 - platform: 'Linux-4.9.0-9-amd64-x86_64-with-debian-9.9'
 	 - machine: 'x86_64'
-	 - version: '#1 SMP Debian 4.9.110-3+deb9u6 (2018-10-08)'
+	 - version: '#1 SMP Debian 4.9.168-1+deb9u2 (2019-05-13)'
 	 - system: 'Linux'
 	 - processor: ''
 	 - python_build: ('default', 'Sep 27 2018 17:25:39')
@@ -15,67 +15,67 @@ Model Information:
 	 - python_implementation: 'CPython'
 	 - python_revision: ''
 	 - python_version: '3.5.3'
-	 - release: '4.9.0-8-amd64'
+	 - release: '4.9.0-9-amd64'
 	
 	Statistics:
-	counts (n=119890):
+	counts (n=119869):
 		label         n         ~True    ~False
 		-------  ------  ---  -------  --------
-		True     119437  -->   119319       118
-		False       453  -->      349       104
+		True     119723  -->   119592       131
+		False       146  -->       57        89
 	rates:
 		              True    False
 		----------  ------  -------
-		sample       0.996    0.004
+		sample       0.999    0.001
 		population   0.996    0.004
-	match_rate (micro=0.994, macro=0.5):
+	match_rate (micro=0.993, macro=0.5):
 		  False    True
 		-------  ------
-		  0.002   0.998
-	filter_rate (micro=0.006, macro=0.5):
+		  0.003   0.997
+	filter_rate (micro=0.007, macro=0.5):
 		  False    True
 		-------  ------
-		  0.998   0.002
-	recall (micro=0.996, macro=0.614):
+		  0.997   0.003
+	recall (micro=0.997, macro=0.804):
 		  False    True
 		-------  ------
-		   0.23   0.999
-	!recall (micro=0.233, macro=0.614):
+		   0.61   0.999
+	!recall (micro=0.611, macro=0.804):
 		  False    True
 		-------  ------
-		  0.999    0.23
-	precision (micro=0.995, macro=0.734):
+		  0.999    0.61
+	precision (micro=0.997, macro=0.84):
 		  False    True
 		-------  ------
-		  0.471   0.997
-	!precision (micro=0.473, macro=0.734):
+		  0.681   0.999
+	!precision (micro=0.682, macro=0.84):
 		  False    True
 		-------  ------
-		  0.997   0.471
-	f1 (micro=0.995, macro=0.653):
+		  0.999   0.681
+	f1 (micro=0.997, macro=0.821):
 		  False    True
 		-------  ------
-		  0.309   0.998
-	!f1 (micro=0.311, macro=0.653):
+		  0.643   0.999
+	!f1 (micro=0.645, macro=0.821):
 		  False    True
 		-------  ------
-		  0.998   0.309
-	accuracy (micro=0.996, macro=0.996):
+		  0.999   0.643
+	accuracy (micro=0.997, macro=0.997):
 		  False    True
 		-------  ------
-		  0.996   0.996
-	fpr (micro=0.767, macro=0.386):
+		  0.997   0.997
+	fpr (micro=0.389, macro=0.196):
 		  False    True
 		-------  ------
-		  0.001    0.77
-	roc_auc (micro=0.993, macro=0.921):
+		  0.001    0.39
+	roc_auc (micro=0.995, macro=0.991):
 		  False    True
 		-------  ------
-		  0.849   0.993
-	pr_auc (micro=0.996, macro=0.631):
+		  0.988   0.995
+	pr_auc (micro=0.999, macro=0.819):
 		  False    True
 		-------  ------
-		  0.264   0.999
+		  0.638       1
 	
-	 - score_schema: {'title': 'Scikit learn-based classifier score with probability', 'properties': {'prediction': {'description': 'The most likely label predicted by the estimator', 'type': 'boolean'}, 'probability': {'properties': {'true': {'type': 'number'}, 'false': {'type': 'number'}}, 'type': 'object', 'description': 'A mapping of probabilities onto each of the potential output labels'}}, 'type': 'object'}
+	 - score_schema: {'title': 'Scikit learn-based classifier score with probability', 'type': 'object', 'properties': {'probability': {'type': 'object', 'description': 'A mapping of probabilities onto each of the potential output labels', 'properties': {'true': {'type': 'number'}, 'false': {'type': 'number'}}}, 'prediction': {'type': 'boolean', 'description': 'The most likely label predicted by the estimator'}}}
 

--- a/models/srwiki.damaging.gradient_boosting.model
+++ b/models/srwiki.damaging.gradient_boosting.model
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:18c0d1bb4789589514f81055327ebee7190c6b993e4f5a2d9f877cfdbf974dcc
-size 10117324
+oid sha256:28920e08360a0f4fbb4b07332b2d1cdcc6a3e56cef653b3d5de5e828decc6d51
+size 9723391

--- a/models/srwiki.goodfaith.gradient_boosting.model
+++ b/models/srwiki.goodfaith.gradient_boosting.model
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9e38d9f6a023e6bfac62a59eb9feb9afb14fc95ed0624f8cd495e1cee207b5d6
-size 8397728
+oid sha256:0fc603798291cf3332652441441c4acf1e203818b66b6ef86ba615aa7bd05b44
+size 2171389

--- a/templates/Makefile.j2
+++ b/templates/Makefile.j2
@@ -125,8 +125,8 @@ tuning_reports/{{ wiki.name }}.{{ model_name }}.md: \
 		config/classifiers.params.yaml \
 		editquality.feature_lists.{{ wiki.name }}.{{ model_name }} \
 		{{ model.label }} \
-		roc_auc.labels.true \
-		--label-weight $({{ model_name }}_label_weight) \
+		$({{ model_name }}_tuning_statistic) \
+		--label-weight $({{ model_name }}_weight) \
 		--pop-rate "true={{ model.pop_rate_true }}" \
 		--pop-rate "false={{ 1 - model.pop_rate_true }}" \
 		--center --scale \

--- a/tuning_reports/srwiki.goodfaith.md
+++ b/tuning_reports/srwiki.goodfaith.md
@@ -1,186 +1,185 @@
 # Model tuning report
-- Revscoring version: 2.2.3
+- Revscoring version: 2.4.0
 - Features: editquality.feature_lists.srwiki.goodfaith
-- Date: 2018-05-23T19:29:19.595163
-- Observations: 118840
+- Date: 2019-05-29T18:27:00.533705
+- Observations: 119869
 - Labels: [true, false]
-- Statistic: roc_auc.labels.true (maximize)
+- Statistic: roc_auc.labels.false (maximize)
 - Folds: 5
 
 # Top scoring configurations
-| model                  |   roc_auc.labels.true | params                                                                        |
-|:-----------------------|----------------------:|:------------------------------------------------------------------------------|
-| GradientBoosting       |                0.9933 | n_estimators=700, max_depth=7, learning_rate=0.1, max_features="log2"         |
-| GradientBoosting       |                0.9921 | n_estimators=300, max_depth=7, learning_rate=0.5, max_features="log2"         |
-| GradientBoosting       |                0.992  | n_estimators=500, max_depth=7, learning_rate=0.1, max_features="log2"         |
-| GradientBoosting       |                0.9904 | n_estimators=300, max_depth=5, learning_rate=0.5, max_features="log2"         |
-| RandomForestClassifier |                0.99   | criterion="entropy", n_estimators=10, min_samples_leaf=1, max_features="log2" |
-| GradientBoosting       |                0.9893 | n_estimators=500, max_depth=5, learning_rate=0.5, max_features="log2"         |
-| RandomForestClassifier |                0.9892 | criterion="gini", n_estimators=10, min_samples_leaf=1, max_features="log2"    |
-| RandomForestClassifier |                0.9878 | criterion="gini", n_estimators=20, min_samples_leaf=1, max_features="log2"    |
-| RandomForestClassifier |                0.9875 | criterion="entropy", n_estimators=20, min_samples_leaf=1, max_features="log2" |
-| GradientBoosting       |                0.9875 | n_estimators=700, max_depth=5, learning_rate=0.1, max_features="log2"         |
+| model                  |   roc_auc.labels.false | params                                                                          |
+|:-----------------------|-----------------------:|:--------------------------------------------------------------------------------|
+| RandomForestClassifier |                 0.9882 | n_estimators=640, criterion="entropy", max_features="log2", min_samples_leaf=3  |
+| RandomForestClassifier |                 0.988  | n_estimators=640, criterion="entropy", max_features="log2", min_samples_leaf=7  |
+| RandomForestClassifier |                 0.988  | n_estimators=160, criterion="entropy", max_features="log2", min_samples_leaf=7  |
+| RandomForestClassifier |                 0.9879 | n_estimators=320, criterion="entropy", max_features="log2", min_samples_leaf=13 |
+| RandomForestClassifier |                 0.9879 | n_estimators=640, criterion="gini", max_features="log2", min_samples_leaf=7     |
+| RandomForestClassifier |                 0.9876 | n_estimators=320, criterion="gini", max_features="log2", min_samples_leaf=13    |
+| RandomForestClassifier |                 0.9876 | n_estimators=640, criterion="gini", max_features="log2", min_samples_leaf=13    |
+| RandomForestClassifier |                 0.9874 | n_estimators=320, criterion="gini", max_features="log2", min_samples_leaf=5     |
+| RandomForestClassifier |                 0.9874 | n_estimators=80, criterion="gini", max_features="log2", min_samples_leaf=13     |
+| GradientBoosting       |                 0.9873 | max_depth=5, n_estimators=500, max_features="log2", learning_rate=0.01          |
 
 # Models
-## GaussianNB
-|   roc_auc.labels.true | params   |
-|----------------------:|:---------|
-|                0.9873 |          |
-
 ## RandomForestClassifier
-|   roc_auc.labels.true | params                                                                          |
-|----------------------:|:--------------------------------------------------------------------------------|
-|                0.99   | criterion="entropy", n_estimators=10, min_samples_leaf=1, max_features="log2"   |
-|                0.9892 | criterion="gini", n_estimators=10, min_samples_leaf=1, max_features="log2"      |
-|                0.9878 | criterion="gini", n_estimators=20, min_samples_leaf=1, max_features="log2"      |
-|                0.9875 | criterion="entropy", n_estimators=20, min_samples_leaf=1, max_features="log2"   |
-|                0.9861 | criterion="gini", n_estimators=40, min_samples_leaf=1, max_features="log2"      |
-|                0.9861 | criterion="entropy", n_estimators=80, min_samples_leaf=1, max_features="log2"   |
-|                0.9861 | criterion="entropy", n_estimators=40, min_samples_leaf=1, max_features="log2"   |
-|                0.986  | criterion="entropy", n_estimators=320, min_samples_leaf=5, max_features="log2"  |
-|                0.9859 | criterion="entropy", n_estimators=320, min_samples_leaf=13, max_features="log2" |
-|                0.9858 | criterion="entropy", n_estimators=320, min_samples_leaf=7, max_features="log2"  |
-|                0.9857 | criterion="entropy", n_estimators=640, min_samples_leaf=7, max_features="log2"  |
-|                0.9856 | criterion="entropy", n_estimators=160, min_samples_leaf=7, max_features="log2"  |
-|                0.9856 | criterion="entropy", n_estimators=160, min_samples_leaf=13, max_features="log2" |
-|                0.9856 | criterion="entropy", n_estimators=640, min_samples_leaf=13, max_features="log2" |
-|                0.9855 | criterion="entropy", n_estimators=80, min_samples_leaf=3, max_features="log2"   |
-|                0.9855 | criterion="entropy", n_estimators=160, min_samples_leaf=5, max_features="log2"  |
-|                0.9854 | criterion="entropy", n_estimators=80, min_samples_leaf=7, max_features="log2"   |
-|                0.9854 | criterion="entropy", n_estimators=80, min_samples_leaf=5, max_features="log2"   |
-|                0.9854 | criterion="entropy", n_estimators=160, min_samples_leaf=1, max_features="log2"  |
-|                0.9853 | criterion="gini", n_estimators=640, min_samples_leaf=7, max_features="log2"     |
-|                0.9853 | criterion="gini", n_estimators=640, min_samples_leaf=13, max_features="log2"    |
-|                0.9853 | criterion="entropy", n_estimators=640, min_samples_leaf=3, max_features="log2"  |
-|                0.9853 | criterion="gini", n_estimators=160, min_samples_leaf=7, max_features="log2"     |
-|                0.9852 | criterion="entropy", n_estimators=640, min_samples_leaf=5, max_features="log2"  |
-|                0.9852 | criterion="gini", n_estimators=640, min_samples_leaf=3, max_features="log2"     |
-|                0.9852 | criterion="entropy", n_estimators=320, min_samples_leaf=1, max_features="log2"  |
-|                0.9851 | criterion="gini", n_estimators=160, min_samples_leaf=5, max_features="log2"     |
-|                0.985  | criterion="gini", n_estimators=640, min_samples_leaf=1, max_features="log2"     |
-|                0.985  | criterion="entropy", n_estimators=80, min_samples_leaf=13, max_features="log2"  |
-|                0.985  | criterion="entropy", n_estimators=640, min_samples_leaf=1, max_features="log2"  |
-|                0.9849 | criterion="gini", n_estimators=640, min_samples_leaf=5, max_features="log2"     |
-|                0.9849 | criterion="gini", n_estimators=320, min_samples_leaf=13, max_features="log2"    |
-|                0.9848 | criterion="entropy", n_estimators=40, min_samples_leaf=7, max_features="log2"   |
-|                0.9848 | criterion="gini", n_estimators=80, min_samples_leaf=5, max_features="log2"      |
-|                0.9847 | criterion="gini", n_estimators=320, min_samples_leaf=3, max_features="log2"     |
-|                0.9846 | criterion="gini", n_estimators=320, min_samples_leaf=7, max_features="log2"     |
-|                0.9845 | criterion="gini", n_estimators=320, min_samples_leaf=5, max_features="log2"     |
-|                0.9844 | criterion="gini", n_estimators=160, min_samples_leaf=13, max_features="log2"    |
-|                0.9844 | criterion="entropy", n_estimators=320, min_samples_leaf=3, max_features="log2"  |
-|                0.9843 | criterion="entropy", n_estimators=20, min_samples_leaf=13, max_features="log2"  |
-|                0.9843 | criterion="gini", n_estimators=160, min_samples_leaf=3, max_features="log2"     |
-|                0.9843 | criterion="gini", n_estimators=10, min_samples_leaf=3, max_features="log2"      |
-|                0.9843 | criterion="gini", n_estimators=80, min_samples_leaf=13, max_features="log2"     |
-|                0.9842 | criterion="entropy", n_estimators=20, min_samples_leaf=3, max_features="log2"   |
-|                0.9842 | criterion="gini", n_estimators=320, min_samples_leaf=1, max_features="log2"     |
-|                0.984  | criterion="entropy", n_estimators=40, min_samples_leaf=13, max_features="log2"  |
-|                0.984  | criterion="entropy", n_estimators=40, min_samples_leaf=3, max_features="log2"   |
-|                0.984  | criterion="gini", n_estimators=40, min_samples_leaf=3, max_features="log2"      |
-|                0.9839 | criterion="gini", n_estimators=10, min_samples_leaf=5, max_features="log2"      |
-|                0.9838 | criterion="entropy", n_estimators=160, min_samples_leaf=3, max_features="log2"  |
-|                0.9838 | criterion="entropy", n_estimators=10, min_samples_leaf=3, max_features="log2"   |
-|                0.9838 | criterion="gini", n_estimators=80, min_samples_leaf=3, max_features="log2"      |
-|                0.9837 | criterion="gini", n_estimators=80, min_samples_leaf=1, max_features="log2"      |
-|                0.9837 | criterion="gini", n_estimators=40, min_samples_leaf=7, max_features="log2"      |
-|                0.9837 | criterion="gini", n_estimators=160, min_samples_leaf=1, max_features="log2"     |
-|                0.9833 | criterion="gini", n_estimators=80, min_samples_leaf=7, max_features="log2"      |
-|                0.9833 | criterion="gini", n_estimators=20, min_samples_leaf=13, max_features="log2"     |
-|                0.9832 | criterion="entropy", n_estimators=20, min_samples_leaf=7, max_features="log2"   |
-|                0.9831 | criterion="gini", n_estimators=40, min_samples_leaf=13, max_features="log2"     |
-|                0.9831 | criterion="entropy", n_estimators=10, min_samples_leaf=7, max_features="log2"   |
-|                0.983  | criterion="gini", n_estimators=40, min_samples_leaf=5, max_features="log2"      |
-|                0.9829 | criterion="gini", n_estimators=20, min_samples_leaf=3, max_features="log2"      |
-|                0.9829 | criterion="gini", n_estimators=20, min_samples_leaf=5, max_features="log2"      |
-|                0.9828 | criterion="entropy", n_estimators=20, min_samples_leaf=5, max_features="log2"   |
-|                0.9824 | criterion="gini", n_estimators=20, min_samples_leaf=7, max_features="log2"      |
-|                0.9824 | criterion="entropy", n_estimators=40, min_samples_leaf=5, max_features="log2"   |
-|                0.9822 | criterion="entropy", n_estimators=10, min_samples_leaf=5, max_features="log2"   |
-|                0.9821 | criterion="gini", n_estimators=10, min_samples_leaf=13, max_features="log2"     |
-|                0.9787 | criterion="entropy", n_estimators=10, min_samples_leaf=13, max_features="log2"  |
-|                0.9787 | criterion="gini", n_estimators=10, min_samples_leaf=7, max_features="log2"      |
-
-## BernoulliNB
-|   roc_auc.labels.true | params   |
-|----------------------:|:---------|
-|                0.9506 |          |
-
-## LogisticRegression
-|   roc_auc.labels.true | params              |
-|----------------------:|:--------------------|
-|                0.984  | C=1, penalty="l1"   |
-|                0.9808 | C=0.1, penalty="l1" |
-|                0.9803 | C=10, penalty="l1"  |
-|                0.8147 | C=10, penalty="l2"  |
-|                0.7917 | C=0.1, penalty="l2" |
-|                0.7788 | C=1, penalty="l2"   |
+|   roc_auc.labels.false | params                                                                          |
+|-----------------------:|:--------------------------------------------------------------------------------|
+|                 0.9882 | n_estimators=640, criterion="entropy", max_features="log2", min_samples_leaf=3  |
+|                 0.988  | n_estimators=640, criterion="entropy", max_features="log2", min_samples_leaf=7  |
+|                 0.988  | n_estimators=160, criterion="entropy", max_features="log2", min_samples_leaf=7  |
+|                 0.9879 | n_estimators=320, criterion="entropy", max_features="log2", min_samples_leaf=13 |
+|                 0.9879 | n_estimators=640, criterion="gini", max_features="log2", min_samples_leaf=7     |
+|                 0.9876 | n_estimators=320, criterion="gini", max_features="log2", min_samples_leaf=13    |
+|                 0.9876 | n_estimators=640, criterion="gini", max_features="log2", min_samples_leaf=13    |
+|                 0.9874 | n_estimators=320, criterion="gini", max_features="log2", min_samples_leaf=5     |
+|                 0.9874 | n_estimators=80, criterion="gini", max_features="log2", min_samples_leaf=13     |
+|                 0.9873 | n_estimators=320, criterion="gini", max_features="log2", min_samples_leaf=7     |
+|                 0.985  | n_estimators=40, criterion="gini", max_features="log2", min_samples_leaf=5      |
+|                 0.9846 | n_estimators=160, criterion="entropy", max_features="log2", min_samples_leaf=5  |
+|                 0.9846 | n_estimators=320, criterion="entropy", max_features="log2", min_samples_leaf=3  |
+|                 0.9845 | n_estimators=640, criterion="gini", max_features="log2", min_samples_leaf=5     |
+|                 0.9844 | n_estimators=640, criterion="gini", max_features="log2", min_samples_leaf=1     |
+|                 0.9844 | n_estimators=80, criterion="gini", max_features="log2", min_samples_leaf=7      |
+|                 0.9844 | n_estimators=640, criterion="entropy", max_features="log2", min_samples_leaf=5  |
+|                 0.9843 | n_estimators=640, criterion="gini", max_features="log2", min_samples_leaf=3     |
+|                 0.9841 | n_estimators=160, criterion="entropy", max_features="log2", min_samples_leaf=13 |
+|                 0.9841 | n_estimators=160, criterion="gini", max_features="log2", min_samples_leaf=7     |
+|                 0.9841 | n_estimators=160, criterion="gini", max_features="log2", min_samples_leaf=13    |
+|                 0.984  | n_estimators=640, criterion="entropy", max_features="log2", min_samples_leaf=13 |
+|                 0.9838 | n_estimators=160, criterion="gini", max_features="log2", min_samples_leaf=5     |
+|                 0.9819 | n_estimators=320, criterion="gini", max_features="log2", min_samples_leaf=1     |
+|                 0.9815 | n_estimators=320, criterion="gini", max_features="log2", min_samples_leaf=3     |
+|                 0.9813 | n_estimators=320, criterion="entropy", max_features="log2", min_samples_leaf=5  |
+|                 0.9813 | n_estimators=320, criterion="entropy", max_features="log2", min_samples_leaf=7  |
+|                 0.9813 | n_estimators=40, criterion="entropy", max_features="log2", min_samples_leaf=5   |
+|                 0.9813 | n_estimators=80, criterion="entropy", max_features="log2", min_samples_leaf=7   |
+|                 0.9806 | n_estimators=160, criterion="gini", max_features="log2", min_samples_leaf=3     |
+|                 0.9779 | n_estimators=80, criterion="gini", max_features="log2", min_samples_leaf=5      |
+|                 0.9778 | n_estimators=20, criterion="entropy", max_features="log2", min_samples_leaf=13  |
+|                 0.9776 | n_estimators=80, criterion="entropy", max_features="log2", min_samples_leaf=13  |
+|                 0.9774 | n_estimators=40, criterion="entropy", max_features="log2", min_samples_leaf=7   |
+|                 0.9749 | n_estimators=40, criterion="gini", max_features="log2", min_samples_leaf=3      |
+|                 0.9749 | n_estimators=20, criterion="gini", max_features="log2", min_samples_leaf=7      |
+|                 0.9748 | n_estimators=640, criterion="entropy", max_features="log2", min_samples_leaf=1  |
+|                 0.9748 | n_estimators=80, criterion="gini", max_features="log2", min_samples_leaf=3      |
+|                 0.9747 | n_estimators=80, criterion="entropy", max_features="log2", min_samples_leaf=3   |
+|                 0.9747 | n_estimators=320, criterion="entropy", max_features="log2", min_samples_leaf=1  |
+|                 0.9746 | n_estimators=80, criterion="entropy", max_features="log2", min_samples_leaf=5   |
+|                 0.9738 | n_estimators=40, criterion="gini", max_features="log2", min_samples_leaf=13     |
+|                 0.9738 | n_estimators=40, criterion="gini", max_features="log2", min_samples_leaf=7      |
+|                 0.9718 | n_estimators=20, criterion="entropy", max_features="log2", min_samples_leaf=7   |
+|                 0.9717 | n_estimators=160, criterion="entropy", max_features="log2", min_samples_leaf=1  |
+|                 0.971  | n_estimators=20, criterion="gini", max_features="log2", min_samples_leaf=13     |
+|                 0.9709 | n_estimators=160, criterion="entropy", max_features="log2", min_samples_leaf=3  |
+|                 0.9707 | n_estimators=40, criterion="entropy", max_features="log2", min_samples_leaf=13  |
+|                 0.9649 | n_estimators=160, criterion="gini", max_features="log2", min_samples_leaf=1     |
+|                 0.9616 | n_estimators=40, criterion="entropy", max_features="log2", min_samples_leaf=3   |
+|                 0.9612 | n_estimators=10, criterion="gini", max_features="log2", min_samples_leaf=7      |
+|                 0.9609 | n_estimators=10, criterion="entropy", max_features="log2", min_samples_leaf=13  |
+|                 0.9605 | n_estimators=10, criterion="gini", max_features="log2", min_samples_leaf=13     |
+|                 0.9578 | n_estimators=20, criterion="entropy", max_features="log2", min_samples_leaf=5   |
+|                 0.9574 | n_estimators=20, criterion="gini", max_features="log2", min_samples_leaf=5      |
+|                 0.9557 | n_estimators=10, criterion="entropy", max_features="log2", min_samples_leaf=5   |
+|                 0.9514 | n_estimators=20, criterion="gini", max_features="log2", min_samples_leaf=3      |
+|                 0.9513 | n_estimators=10, criterion="gini", max_features="log2", min_samples_leaf=5      |
+|                 0.9483 | n_estimators=10, criterion="entropy", max_features="log2", min_samples_leaf=7   |
+|                 0.945  | n_estimators=20, criterion="entropy", max_features="log2", min_samples_leaf=3   |
+|                 0.9358 | n_estimators=10, criterion="entropy", max_features="log2", min_samples_leaf=3   |
+|                 0.9353 | n_estimators=40, criterion="gini", max_features="log2", min_samples_leaf=1      |
+|                 0.9348 | n_estimators=80, criterion="gini", max_features="log2", min_samples_leaf=1      |
+|                 0.9318 | n_estimators=10, criterion="gini", max_features="log2", min_samples_leaf=3      |
+|                 0.9316 | n_estimators=80, criterion="entropy", max_features="log2", min_samples_leaf=1   |
+|                 0.9287 | n_estimators=40, criterion="entropy", max_features="log2", min_samples_leaf=1   |
+|                 0.9121 | n_estimators=20, criterion="entropy", max_features="log2", min_samples_leaf=1   |
+|                 0.8984 | n_estimators=20, criterion="gini", max_features="log2", min_samples_leaf=1      |
+|                 0.8718 | n_estimators=10, criterion="gini", max_features="log2", min_samples_leaf=1      |
+|                 0.8717 | n_estimators=10, criterion="entropy", max_features="log2", min_samples_leaf=1   |
 
 ## GradientBoosting
-|   roc_auc.labels.true | params                                                                 |
-|----------------------:|:-----------------------------------------------------------------------|
-|                0.9933 | n_estimators=700, max_depth=7, learning_rate=0.1, max_features="log2"  |
-|                0.9921 | n_estimators=300, max_depth=7, learning_rate=0.5, max_features="log2"  |
-|                0.992  | n_estimators=500, max_depth=7, learning_rate=0.1, max_features="log2"  |
-|                0.9904 | n_estimators=300, max_depth=5, learning_rate=0.5, max_features="log2"  |
-|                0.9893 | n_estimators=500, max_depth=5, learning_rate=0.5, max_features="log2"  |
-|                0.9875 | n_estimators=700, max_depth=5, learning_rate=0.1, max_features="log2"  |
-|                0.9862 | n_estimators=700, max_depth=7, learning_rate=0.5, max_features="log2"  |
-|                0.986  | n_estimators=500, max_depth=5, learning_rate=0.1, max_features="log2"  |
-|                0.986  | n_estimators=700, max_depth=5, learning_rate=0.01, max_features="log2" |
-|                0.9856 | n_estimators=500, max_depth=7, learning_rate=0.01, max_features="log2" |
-|                0.9853 | n_estimators=100, max_depth=7, learning_rate=0.5, max_features="log2"  |
-|                0.9844 | n_estimators=300, max_depth=5, learning_rate=0.1, max_features="log2"  |
-|                0.9843 | n_estimators=300, max_depth=7, learning_rate=0.01, max_features="log2" |
-|                0.9841 | n_estimators=700, max_depth=3, learning_rate=0.5, max_features="log2"  |
-|                0.9835 | n_estimators=100, max_depth=5, learning_rate=0.5, max_features="log2"  |
-|                0.9833 | n_estimators=100, max_depth=7, learning_rate=0.1, max_features="log2"  |
-|                0.9833 | n_estimators=100, max_depth=3, learning_rate=0.1, max_features="log2"  |
-|                0.9829 | n_estimators=700, max_depth=3, learning_rate=0.1, max_features="log2"  |
-|                0.9828 | n_estimators=500, max_depth=3, learning_rate=0.1, max_features="log2"  |
-|                0.9816 | n_estimators=100, max_depth=7, learning_rate=1, max_features="log2"    |
-|                0.9816 | n_estimators=300, max_depth=7, learning_rate=0.1, max_features="log2"  |
-|                0.9814 | n_estimators=300, max_depth=3, learning_rate=0.1, max_features="log2"  |
-|                0.9814 | n_estimators=500, max_depth=5, learning_rate=0.01, max_features="log2" |
-|                0.9812 | n_estimators=100, max_depth=5, learning_rate=1, max_features="log2"    |
-|                0.9805 | n_estimators=700, max_depth=7, learning_rate=0.01, max_features="log2" |
-|                0.9802 | n_estimators=300, max_depth=1, learning_rate=0.1, max_features="log2"  |
-|                0.9802 | n_estimators=500, max_depth=1, learning_rate=0.5, max_features="log2"  |
-|                0.9794 | n_estimators=100, max_depth=5, learning_rate=0.1, max_features="log2"  |
-|                0.9792 | n_estimators=700, max_depth=3, learning_rate=1, max_features="log2"    |
-|                0.9792 | n_estimators=300, max_depth=1, learning_rate=0.5, max_features="log2"  |
-|                0.9791 | n_estimators=100, max_depth=5, learning_rate=0.01, max_features="log2" |
-|                0.979  | n_estimators=700, max_depth=1, learning_rate=0.1, max_features="log2"  |
-|                0.9788 | n_estimators=100, max_depth=7, learning_rate=0.01, max_features="log2" |
-|                0.9785 | n_estimators=500, max_depth=1, learning_rate=0.1, max_features="log2"  |
-|                0.9783 | n_estimators=700, max_depth=3, learning_rate=0.01, max_features="log2" |
-|                0.9783 | n_estimators=300, max_depth=5, learning_rate=0.01, max_features="log2" |
-|                0.978  | n_estimators=300, max_depth=3, learning_rate=1, max_features="log2"    |
-|                0.9778 | n_estimators=300, max_depth=3, learning_rate=0.01, max_features="log2" |
-|                0.9778 | n_estimators=500, max_depth=3, learning_rate=0.01, max_features="log2" |
-|                0.9773 | n_estimators=100, max_depth=1, learning_rate=0.5, max_features="log2"  |
-|                0.9769 | n_estimators=300, max_depth=3, learning_rate=0.5, max_features="log2"  |
-|                0.9757 | n_estimators=100, max_depth=1, learning_rate=0.1, max_features="log2"  |
-|                0.9752 | n_estimators=700, max_depth=1, learning_rate=0.01, max_features="log2" |
-|                0.9751 | n_estimators=100, max_depth=3, learning_rate=1, max_features="log2"    |
-|                0.9746 | n_estimators=100, max_depth=3, learning_rate=0.01, max_features="log2" |
-|                0.9731 | n_estimators=500, max_depth=1, learning_rate=0.01, max_features="log2" |
-|                0.9728 | n_estimators=500, max_depth=3, learning_rate=1, max_features="log2"    |
-|                0.9703 | n_estimators=500, max_depth=3, learning_rate=0.5, max_features="log2"  |
-|                0.9694 | n_estimators=700, max_depth=1, learning_rate=0.5, max_features="log2"  |
-|                0.9681 | n_estimators=300, max_depth=1, learning_rate=0.01, max_features="log2" |
-|                0.9624 | n_estimators=100, max_depth=3, learning_rate=0.5, max_features="log2"  |
-|                0.9623 | n_estimators=100, max_depth=1, learning_rate=0.01, max_features="log2" |
-|                0.9621 | n_estimators=700, max_depth=5, learning_rate=1, max_features="log2"    |
-|                0.961  | n_estimators=500, max_depth=7, learning_rate=0.5, max_features="log2"  |
-|                0.9591 | n_estimators=300, max_depth=7, learning_rate=1, max_features="log2"    |
-|                0.9587 | n_estimators=700, max_depth=5, learning_rate=0.5, max_features="log2"  |
-|                0.9502 | n_estimators=100, max_depth=1, learning_rate=1, max_features="log2"    |
-|                0.9396 | n_estimators=500, max_depth=5, learning_rate=1, max_features="log2"    |
-|                0.9356 | n_estimators=500, max_depth=1, learning_rate=1, max_features="log2"    |
-|                0.917  | n_estimators=300, max_depth=1, learning_rate=1, max_features="log2"    |
-|                0.8661 | n_estimators=500, max_depth=7, learning_rate=1, max_features="log2"    |
-|                0.8451 | n_estimators=300, max_depth=5, learning_rate=1, max_features="log2"    |
-|                0.828  | n_estimators=700, max_depth=7, learning_rate=1, max_features="log2"    |
-|                0.7845 | n_estimators=700, max_depth=1, learning_rate=1, max_features="log2"    |
+|   roc_auc.labels.false | params                                                                 |
+|-----------------------:|:-----------------------------------------------------------------------|
+|                 0.9873 | max_depth=5, n_estimators=500, max_features="log2", learning_rate=0.01 |
+|                 0.9872 | max_depth=7, n_estimators=300, max_features="log2", learning_rate=0.01 |
+|                 0.9872 | max_depth=3, n_estimators=700, max_features="log2", learning_rate=0.01 |
+|                 0.987  | max_depth=5, n_estimators=300, max_features="log2", learning_rate=0.01 |
+|                 0.9861 | max_depth=1, n_estimators=300, max_features="log2", learning_rate=0.1  |
+|                 0.986  | max_depth=7, n_estimators=100, max_features="log2", learning_rate=0.01 |
+|                 0.986  | max_depth=3, n_estimators=500, max_features="log2", learning_rate=0.01 |
+|                 0.9853 | max_depth=5, n_estimators=100, max_features="log2", learning_rate=0.01 |
+|                 0.985  | max_depth=5, n_estimators=700, max_features="log2", learning_rate=0.01 |
+|                 0.985  | max_depth=3, n_estimators=300, max_features="log2", learning_rate=0.01 |
+|                 0.9841 | max_depth=7, n_estimators=500, max_features="log2", learning_rate=0.01 |
+|                 0.9838 | max_depth=1, n_estimators=700, max_features="log2", learning_rate=0.01 |
+|                 0.9837 | max_depth=3, n_estimators=100, max_features="log2", learning_rate=0.01 |
+|                 0.9837 | max_depth=1, n_estimators=500, max_features="log2", learning_rate=0.01 |
+|                 0.9829 | max_depth=3, n_estimators=100, max_features="log2", learning_rate=0.1  |
+|                 0.9829 | max_depth=1, n_estimators=300, max_features="log2", learning_rate=0.01 |
+|                 0.9809 | max_depth=1, n_estimators=700, max_features="log2", learning_rate=0.1  |
+|                 0.9808 | max_depth=1, n_estimators=500, max_features="log2", learning_rate=0.1  |
+|                 0.9801 | max_depth=1, n_estimators=100, max_features="log2", learning_rate=0.01 |
+|                 0.9797 | max_depth=1, n_estimators=100, max_features="log2", learning_rate=0.1  |
+|                 0.9788 | max_depth=7, n_estimators=700, max_features="log2", learning_rate=0.01 |
+|                 0.9722 | max_depth=3, n_estimators=500, max_features="log2", learning_rate=0.1  |
+|                 0.9716 | max_depth=5, n_estimators=100, max_features="log2", learning_rate=0.1  |
+|                 0.9716 | max_depth=3, n_estimators=300, max_features="log2", learning_rate=0.1  |
+|                 0.964  | max_depth=1, n_estimators=700, max_features="log2", learning_rate=0.5  |
+|                 0.9627 | max_depth=3, n_estimators=700, max_features="log2", learning_rate=0.1  |
+|                 0.9587 | max_depth=1, n_estimators=100, max_features="log2", learning_rate=0.5  |
+|                 0.9544 | max_depth=1, n_estimators=500, max_features="log2", learning_rate=0.5  |
+|                 0.939  | max_depth=5, n_estimators=300, max_features="log2", learning_rate=0.1  |
+|                 0.9387 | max_depth=7, n_estimators=100, max_features="log2", learning_rate=0.1  |
+|                 0.8873 | max_depth=1, n_estimators=300, max_features="log2", learning_rate=0.5  |
+|                 0.8858 | max_depth=7, n_estimators=700, max_features="log2", learning_rate=0.1  |
+|                 0.8855 | max_depth=5, n_estimators=500, max_features="log2", learning_rate=0.1  |
+|                 0.8854 | max_depth=5, n_estimators=700, max_features="log2", learning_rate=0.1  |
+|                 0.8757 | max_depth=7, n_estimators=500, max_features="log2", learning_rate=0.1  |
+|                 0.8753 | max_depth=7, n_estimators=300, max_features="log2", learning_rate=0.1  |
+|                 0.8702 | max_depth=3, n_estimators=100, max_features="log2", learning_rate=0.5  |
+|                 0.8298 | max_depth=3, n_estimators=500, max_features="log2", learning_rate=0.5  |
+|                 0.8052 | max_depth=3, n_estimators=300, max_features="log2", learning_rate=0.5  |
+|                 0.7787 | max_depth=5, n_estimators=100, max_features="log2", learning_rate=0.5  |
+|                 0.7786 | max_depth=5, n_estimators=500, max_features="log2", learning_rate=1    |
+|                 0.7784 | max_depth=3, n_estimators=100, max_features="log2", learning_rate=1    |
+|                 0.7748 | max_depth=3, n_estimators=300, max_features="log2", learning_rate=1    |
+|                 0.77   | max_depth=5, n_estimators=700, max_features="log2", learning_rate=1    |
+|                 0.7528 | max_depth=5, n_estimators=300, max_features="log2", learning_rate=0.5  |
+|                 0.7357 | max_depth=3, n_estimators=500, max_features="log2", learning_rate=1    |
+|                 0.7301 | max_depth=3, n_estimators=700, max_features="log2", learning_rate=0.5  |
+|                 0.7285 | max_depth=1, n_estimators=300, max_features="log2", learning_rate=1    |
+|                 0.7219 | max_depth=7, n_estimators=700, max_features="log2", learning_rate=1    |
+|                 0.7171 | max_depth=5, n_estimators=300, max_features="log2", learning_rate=1    |
+|                 0.7146 | max_depth=5, n_estimators=700, max_features="log2", learning_rate=0.5  |
+|                 0.6953 | max_depth=5, n_estimators=500, max_features="log2", learning_rate=0.5  |
+|                 0.6945 | max_depth=1, n_estimators=500, max_features="log2", learning_rate=1    |
+|                 0.6943 | max_depth=5, n_estimators=100, max_features="log2", learning_rate=1    |
+|                 0.6794 | max_depth=7, n_estimators=500, max_features="log2", learning_rate=0.5  |
+|                 0.675  | max_depth=7, n_estimators=700, max_features="log2", learning_rate=0.5  |
+|                 0.6749 | max_depth=1, n_estimators=100, max_features="log2", learning_rate=1    |
+|                 0.6715 | max_depth=7, n_estimators=100, max_features="log2", learning_rate=0.5  |
+|                 0.6671 | max_depth=7, n_estimators=300, max_features="log2", learning_rate=0.5  |
+|                 0.6665 | max_depth=7, n_estimators=500, max_features="log2", learning_rate=1    |
+|                 0.6395 | max_depth=7, n_estimators=100, max_features="log2", learning_rate=1    |
+|                 0.6241 | max_depth=7, n_estimators=300, max_features="log2", learning_rate=1    |
+|                 0.5264 | max_depth=3, n_estimators=700, max_features="log2", learning_rate=1    |
+|                 0.3655 | max_depth=1, n_estimators=700, max_features="log2", learning_rate=1    |
+
+## LogisticRegression
+|   roc_auc.labels.false | params              |
+|-----------------------:|:--------------------|
+|                 0.9782 | C=1, penalty="l1"   |
+|                 0.978  | C=0.1, penalty="l1" |
+|                 0.7792 | C=1, penalty="l2"   |
+|                 0.76   | C=0.1, penalty="l2" |
+|                 0.7556 | C=10, penalty="l2"  |
+
+## BernoulliNB
+|   roc_auc.labels.false | params   |
+|-----------------------:|:---------|
+|                 0.9667 |          |
+
+## GaussianNB
+|   roc_auc.labels.false | params   |
+|-----------------------:|:---------|
+|                 0.9102 |          |
 


### PR DESCRIPTION
Bug: https://phabricator.wikimedia.org/T199355

This pull request updates the labeled dataset for srwiki based on a follow-up labeling campaign.  In this campaign, all of the edits labeled "badfaith" were re-labeled.  This lead to a substantial reduction in the # of badfaith labels and the increase in model fitness suggests that many boundary (or otherwise not-badfaith) cases are now labeled "goodfaith".  

Luckily, I was able to merge in the new labels using the "merge_labels" utility so no substantial changes to the Makefile generation were necessary. 