### PR TITLE
Add doc for generate_make

### DIFF
--- a/editquality/editquality.py
+++ b/editquality/editquality.py
@@ -6,6 +6,7 @@ building edit quality predictors.
 * join_observations -- Joins a set of observations together
 * autolabel -- Labels edits by whether or not they require review
 * get_revisions -- Gathers all revisions from a wiki between two dates
+* generate_make -- Code-generate Makefile from template and configuration
 
 Usage:
     editquality (-h | --help)


### PR DESCRIPTION
This PR adds docs for the `generate_make` command in the help menu.

<img width="664" alt="Screen Shot 2019-06-24 at 3 04 08 PM" src="https://user-images.githubusercontent.com/989447/60055159-8c502e00-9691-11e9-9d7a-01d719016ad2.png">

https://phabricator.wikimedia.org/T226441