### PR TITLE
Release Automation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
   - python setup.py install
   - pip install codecov
   - pip install flake8
+  - pip install twine
   - python -m nltk.downloader stopwords
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
     - myspell-en-za
 
 # command to install dependencies
-install: 
+install:
   - pip install -r requirements.txt
   - python setup.py install
   - pip install codecov
@@ -37,3 +37,9 @@ notifications:
     on_failure: change
     template:
       - "%{repository_slug}#%{build_number} (%{branch} - %{commit} : %{author}): %{message} %{build_url}"
+
+deploy:
+  provider: script
+  script: bash scripts/deploy.sh
+  on:
+    branch: master

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,1 @@
+python setup.py sdist bdist_wheel && twine upload dist/* --skip-existing --username $PYPI_USER --password $PYPI_PASS

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,11 @@ setup(
     },
     long_description=read('README.md'),
     install_requires=requirements('requirements.txt'),
+    extras_require={
+        'dev': [
+            'twine'
+        ],
+    },
     classifiers=[
         "Development Status :: 4 - Beta",
         "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
This PR adds the ability to deploy releases to PyPI via TravisCI.

This is done using a script (`deploy.sh`) which will build the binary and wheels and upload via [twine](https://pypi.org/project/twine/) whenever the version gets incremented in `about.py`.

PYPI Credentials will be stored as private environment variables on the TravisCI repo.