### PR TITLE
Retrain huwiki models

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1970,6 +1970,10 @@ hrwiki_tuning_reports: \
 
 
 ############################# Hungarian Wikipedia ################################
+datasets/huwiki.badfaith_or_damaging_relabeling_revisions.5k_2019.json:
+	./utility fetch_labels \
+		https://labels.wmflabs.org/campaigns/huwiki/92/ > $@
+
 datasets/huwiki.human_labeled_revisions.5k_2016.json:
 	./utility fetch_labels \
 		https://labels.wmflabs.org/campaigns/huwiki/33/ > $@
@@ -1995,13 +1999,18 @@ datasets/huwiki.revisions_for_review.5k_2016.json: \
 	 shuf -n 2500 \
 	) | shuf > $@
 
-datasets/huwiki.labeled_revisions.40k_2016.json: \
+datasets/huwiki.labeled_revisions.40k_2019.json: \
+		datasets/huwiki.badfaith_or_damaging_relabeling_revisions.5k_2019.json \
+		datasets/huwiki.original_labeled_revisions.40k_2016.json
+	./utility merge_labels $^ > $@
+
+datasets/huwiki.original_labeled_revisions.40k_2016.json: \
 		datasets/huwiki.human_labeled_revisions.5k_2016.json \
 		datasets/huwiki.autolabeled_revisions.40k_2016.json
 	./utility merge_labels $^ > $@
 
-datasets/huwiki.labeled_revisions.w_cache.40k_2016.json: \
-		datasets/huwiki.labeled_revisions.40k_2016.json
+datasets/huwiki.labeled_revisions.w_cache.40k_2019.json: \
+		datasets/huwiki.labeled_revisions.40k_2019.json
 	cat $< | \
 	revscoring extract \
 		editquality.feature_lists.huwiki.damaging \
@@ -2011,7 +2020,7 @@ datasets/huwiki.labeled_revisions.w_cache.40k_2016.json: \
 		--verbose > $@
 
 tuning_reports/huwiki.damaging.md: \
-		datasets/huwiki.labeled_revisions.w_cache.40k_2016.json
+		datasets/huwiki.labeled_revisions.w_cache.40k_2019.json
 	cat $< | \
 	revscoring tune \
 		config/classifiers.params.yaml \
@@ -2026,13 +2035,13 @@ tuning_reports/huwiki.damaging.md: \
 		--debug > $@
 
 models/huwiki.damaging.gradient_boosting.model: \
-		datasets/huwiki.labeled_revisions.w_cache.40k_2016.json
+		datasets/huwiki.labeled_revisions.w_cache.40k_2019.json
 	cat $< | \
 	revscoring cv_train \
 		revscoring.scoring.models.GradientBoosting \
 		editquality.feature_lists.huwiki.damaging \
 		damaging \
-		--version=$(damaging_major_minor).0 \
+		--version=$(damaging_major_minor).1 \
 		-p 'learning_rate=0.01' \
 		-p 'max_depth=5' \
 		-p 'max_features="log2"' \
@@ -2045,7 +2054,7 @@ models/huwiki.damaging.gradient_boosting.model: \
 	revscoring model_info $@ > model_info/huwiki.damaging.md
 
 tuning_reports/huwiki.goodfaith.md: \
-		datasets/huwiki.labeled_revisions.w_cache.40k_2016.json
+		datasets/huwiki.labeled_revisions.w_cache.40k_2019.json
 	cat $< | \
 	revscoring tune \
 		config/classifiers.params.yaml \
@@ -2060,17 +2069,17 @@ tuning_reports/huwiki.goodfaith.md: \
 		--debug > $@
 
 models/huwiki.goodfaith.gradient_boosting.model: \
-		datasets/huwiki.labeled_revisions.w_cache.40k_2016.json
+		datasets/huwiki.labeled_revisions.w_cache.40k_2019.json
 	cat $< | \
 	revscoring cv_train \
 		revscoring.scoring.models.GradientBoosting \
 		editquality.feature_lists.huwiki.goodfaith \
 		goodfaith \
-		--version=$(goodfaith_major_minor).0 \
-		-p 'learning_rate=0.1' \
-		-p 'max_depth=7' \
+		--version=$(goodfaith_major_minor).1 \
+		-p 'learning_rate=0.01' \
+		-p 'max_depth=5' \
 		-p 'max_features="log2"' \
-		-p 'n_estimators=700' \
+		-p 'n_estimators=500' \
 		--label-weight $(goodfaith_weight) \
 		--pop-rate "true=0.99221230908" \
 		--pop-rate "false=0.007787690919999979" \

--- a/Makefile
+++ b/Makefile
@@ -1999,7 +1999,7 @@ datasets/huwiki.revisions_for_review.5k_2016.json: \
 	 shuf -n 2500 \
 	) | shuf > $@
 
-datasets/huwiki.labeled_revisions.40k_2019.json: \
+datasets/huwiki.labeled_revisions.40k_2016.json: \
 		datasets/huwiki.badfaith_or_damaging_relabeling_revisions.5k_2019.json \
 		datasets/huwiki.original_labeled_revisions.40k_2016.json
 	./utility merge_labels $^ > $@
@@ -2009,8 +2009,8 @@ datasets/huwiki.original_labeled_revisions.40k_2016.json: \
 		datasets/huwiki.autolabeled_revisions.40k_2016.json
 	./utility merge_labels $^ > $@
 
-datasets/huwiki.labeled_revisions.w_cache.40k_2019.json: \
-		datasets/huwiki.labeled_revisions.40k_2019.json
+datasets/huwiki.labeled_revisions.w_cache.40k_2016.json: \
+		datasets/huwiki.labeled_revisions.40k_2016.json
 	cat $< | \
 	revscoring extract \
 		editquality.feature_lists.huwiki.damaging \
@@ -2020,7 +2020,7 @@ datasets/huwiki.labeled_revisions.w_cache.40k_2019.json: \
 		--verbose > $@
 
 tuning_reports/huwiki.damaging.md: \
-		datasets/huwiki.labeled_revisions.w_cache.40k_2019.json
+		datasets/huwiki.labeled_revisions.w_cache.40k_2016.json
 	cat $< | \
 	revscoring tune \
 		config/classifiers.params.yaml \
@@ -2035,7 +2035,7 @@ tuning_reports/huwiki.damaging.md: \
 		--debug > $@
 
 models/huwiki.damaging.gradient_boosting.model: \
-		datasets/huwiki.labeled_revisions.w_cache.40k_2019.json
+		datasets/huwiki.labeled_revisions.w_cache.40k_2016.json
 	cat $< | \
 	revscoring cv_train \
 		revscoring.scoring.models.GradientBoosting \
@@ -2054,7 +2054,7 @@ models/huwiki.damaging.gradient_boosting.model: \
 	revscoring model_info $@ > model_info/huwiki.damaging.md
 
 tuning_reports/huwiki.goodfaith.md: \
-		datasets/huwiki.labeled_revisions.w_cache.40k_2019.json
+		datasets/huwiki.labeled_revisions.w_cache.40k_2016.json
 	cat $< | \
 	revscoring tune \
 		config/classifiers.params.yaml \
@@ -2069,7 +2069,7 @@ tuning_reports/huwiki.goodfaith.md: \
 		--debug > $@
 
 models/huwiki.goodfaith.gradient_boosting.model: \
-		datasets/huwiki.labeled_revisions.w_cache.40k_2019.json
+		datasets/huwiki.labeled_revisions.w_cache.40k_2016.json
 	cat $< | \
 	revscoring cv_train \
 		revscoring.scoring.models.GradientBoosting \

--- a/config/wikis/huwiki.yaml
+++ b/config/wikis/huwiki.yaml
@@ -7,6 +7,8 @@ external_samples:
     quarry_url: http://quarry.wmflabs.org/run/79645/output/0/json-lines?download=true
   human_labeled_revisions.5k_2016:
     labeling_campaign: https://labels.wmflabs.org/campaigns/huwiki/33/
+  badfaith_or_damaging_relabeling_revisions.5k_2019:
+    labeling_campaign: https://labels.wmflabs.org/campaigns/huwiki/92/
 
 autolabeled_samples:
   trusted_edits: 1000
@@ -29,39 +31,44 @@ balanced_5k_samples:
   revisions_for_review.5k_2016: autolabeled_revisions.40k_2016
 
 merged_samples:
-  labeled_revisions.40k_2016:
+  original_labeled_revisions.40k_2016:
     - human_labeled_revisions.5k_2016
     - autolabeled_revisions.40k_2016
+  labeled_revisions.40k_2019:
+    - badfaith_or_damaging_relabeling_revisions.5k_2019
+    - original_labeled_revisions.40k_2016
 
 extracted_samples:
-  labeled_revisions.w_cache.40k_2016:
-    sample: labeled_revisions.40k_2016
+  labeled_revisions.w_cache.40k_2019:
+    sample: labeled_revisions.40k_2019
     features_for:
       - damaging
       - goodfaith
 
 models:
   damaging:
-    observations: labeled_revisions.w_cache.40k_2016
+    observations: labeled_revisions.w_cache.40k_2019
     label: damaging
     pop_rate_true: 0.01093805131
     tune: true
     cv_train:
       algorithm: GradientBoosting
+      build_number: 1
       parameters:
         learning_rate: 0.01
         max_depth: 5
         max_features: log2
         n_estimators: 500
   goodfaith:
-    observations: labeled_revisions.w_cache.40k_2016
+    observations: labeled_revisions.w_cache.40k_2019
     label: goodfaith
     pop_rate_true: 0.99221230908
     tune: true
     cv_train:
       algorithm: GradientBoosting
+      build_number: 1
       parameters:
-        learning_rate: 0.1
-        max_depth: 7
+        learning_rate: 0.01
+        max_depth: 5
         max_features: log2
-        n_estimators: 700
+        n_estimators: 500

--- a/config/wikis/huwiki.yaml
+++ b/config/wikis/huwiki.yaml
@@ -34,20 +34,20 @@ merged_samples:
   original_labeled_revisions.40k_2016:
     - human_labeled_revisions.5k_2016
     - autolabeled_revisions.40k_2016
-  labeled_revisions.40k_2019:
+  labeled_revisions.40k_2016:
     - badfaith_or_damaging_relabeling_revisions.5k_2019
     - original_labeled_revisions.40k_2016
 
 extracted_samples:
-  labeled_revisions.w_cache.40k_2019:
-    sample: labeled_revisions.40k_2019
+  labeled_revisions.w_cache.40k_2016:
+    sample: labeled_revisions.40k_2016
     features_for:
       - damaging
       - goodfaith
 
 models:
   damaging:
-    observations: labeled_revisions.w_cache.40k_2019
+    observations: labeled_revisions.w_cache.40k_2016
     label: damaging
     pop_rate_true: 0.01093805131
     tune: true
@@ -60,7 +60,7 @@ models:
         max_features: log2
         n_estimators: 500
   goodfaith:
-    observations: labeled_revisions.w_cache.40k_2019
+    observations: labeled_revisions.w_cache.40k_2016
     label: goodfaith
     pop_rate_true: 0.99221230908
     tune: true

--- a/editquality/utilities/merge_labels.py
+++ b/editquality/utilities/merge_labels.py
@@ -103,7 +103,7 @@ def run(human_labels, auto_labels, verbose):
     # Merge human labels onto autolabeled defaults.
     for revision in auto_labels:
         if revision['rev_id'] in human_rev_map:
-            if not revision['autolabel']['needs_review']:
+            if not needs_review(revision):
                 revision.update(AUTO_DEFAULTS)
 
             human_labeled = human_rev_map[revision['rev_id']]
@@ -123,7 +123,7 @@ def run(human_labels, auto_labels, verbose):
             human_rev_ids.remove(revision['rev_id'])
 
         else:
-            if revision['autolabel']['needs_review']:
+            if needs_review(revision):
                 # TODO: Tally these warnings.
                 logger.warning("{0} has no labels, but was flagged for review"
                                .format(revision['rev_id']))
@@ -178,3 +178,11 @@ def has_all_labels(revision, labels):
         if label not in revision:
             return False
     return True
+
+
+def needs_review(revision):
+    """
+    Returns bool if revision needs review.
+    If autolabel is empty, assume true.
+    """
+    return revision['autolabel'].get('needs_review', True)

--- a/editquality/utilities/tests/test_merge_labels.py
+++ b/editquality/utilities/tests/test_merge_labels.py
@@ -147,3 +147,19 @@ def test_merge_labels(human, auto, expected):
     merged = merge_labels.run(human, auto, False)
     merged = list(merged)
     assert expected == merged
+
+
+def test_needs_review():
+    """Test needs review filter."""
+    #  assume needs review if autolabel field is empty
+    revision = {'autolabel': {}}
+    res = merge_labels.needs_review(revision)
+    assert res == True  # noqa
+    #  check false
+    revision = {'autolabel': {'needs_review': False}}
+    res = merge_labels.needs_review(revision)
+    assert res == False  # noqa
+    #  check true
+    revision['autolabel']['needs_review'] = True
+    res = merge_labels.needs_review(revision)
+    assert res == True  # noqa

--- a/model_info/huwiki.damaging.md
+++ b/model_info/huwiki.damaging.md
@@ -1,12 +1,12 @@
 Model Information:
 	 - type: GradientBoosting
-	 - version: 0.5.0
-	 - params: {'label_weights': OrderedDict([(True, 10)]), 'presort': 'auto', 'n_estimators': 500, 'min_samples_split': 2, 'warm_start': False, 'min_samples_leaf': 1, 'center': True, 'learning_rate': 0.01, 'min_impurity_split': None, 'labels': [True, False], 'multilabel': False, 'max_features': 'log2', 'init': None, 'min_impurity_decrease': 0.0, 'population_rates': None, 'criterion': 'friedman_mse', 'verbose': 0, 'max_depth': 5, 'subsample': 1.0, 'loss': 'deviance', 'max_leaf_nodes': None, 'min_weight_fraction_leaf': 0.0, 'random_state': None, 'scale': True}
+	 - version: 0.5.1
+	 - params: {'max_leaf_nodes': None, 'loss': 'deviance', 'warm_start': False, 'min_weight_fraction_leaf': 0.0, 'max_depth': 5, 'criterion': 'friedman_mse', 'label_weights': OrderedDict([(True, 10)]), 'min_impurity_split': None, 'center': True, 'random_state': None, 'scale': True, 'verbose': 0, 'labels': [True, False], 'max_features': 'log2', 'n_estimators': 500, 'learning_rate': 0.01, 'init': None, 'min_impurity_decrease': 0.0, 'min_samples_split': 2, 'min_samples_leaf': 1, 'population_rates': None, 'presort': 'auto', 'subsample': 1.0, 'multilabel': False}
 	Environment:
-	 - revscoring_version: '2.3.4'
-	 - platform: 'Linux-4.9.0-8-amd64-x86_64-with-debian-9.5'
+	 - revscoring_version: '2.4.0'
+	 - platform: 'Linux-4.9.0-9-amd64-x86_64-with-debian-9.9'
 	 - machine: 'x86_64'
-	 - version: '#1 SMP Debian 4.9.110-3+deb9u6 (2018-10-08)'
+	 - version: '#1 SMP Debian 4.9.168-1+deb9u2 (2019-05-13)'
 	 - system: 'Linux'
 	 - processor: ''
 	 - python_build: ('default', 'Sep 27 2018 17:25:39')
@@ -15,67 +15,67 @@ Model Information:
 	 - python_implementation: 'CPython'
 	 - python_revision: ''
 	 - python_version: '3.5.3'
-	 - release: '4.9.0-8-amd64'
+	 - release: '4.9.0-9-amd64'
 	
 	Statistics:
-	counts (n=37755):
+	counts (n=37729):
 		label        n         ~True    ~False
 		-------  -----  ---  -------  --------
-		True       432  -->      256       176
-		False    37323  -->      638     36685
+		True       357  -->      223       134
+		False    37372  -->      570     36802
 	rates:
 		              True    False
 		----------  ------  -------
-		sample       0.011    0.989
+		sample       0.009    0.991
 		population   0.011    0.989
-	match_rate (micro=0.966, macro=0.5):
+	match_rate (micro=0.968, macro=0.5):
 		  False    True
 		-------  ------
-		  0.977   0.023
-	filter_rate (micro=0.034, macro=0.5):
+		  0.978   0.022
+	filter_rate (micro=0.032, macro=0.5):
 		  False    True
 		-------  ------
-		  0.023   0.977
-	recall (micro=0.979, macro=0.788):
+		  0.022   0.978
+	recall (micro=0.981, macro=0.805):
 		  False    True
 		-------  ------
-		  0.983   0.593
-	!recall (micro=0.597, macro=0.788):
+		  0.985   0.625
+	!recall (micro=0.629, macro=0.805):
 		  False    True
 		-------  ------
-		  0.593   0.983
-	precision (micro=0.988, macro=0.636):
+		  0.625   0.985
+	precision (micro=0.988, macro=0.654):
 		  False    True
 		-------  ------
-		  0.995   0.277
-	!precision (micro=0.285, macro=0.636):
+		  0.996   0.312
+	!precision (micro=0.319, macro=0.654):
 		  False    True
 		-------  ------
-		  0.277   0.995
-	f1 (micro=0.982, macro=0.683):
+		  0.312   0.996
+	f1 (micro=0.984, macro=0.703):
 		  False    True
 		-------  ------
-		  0.989   0.378
-	!f1 (micro=0.384, macro=0.683):
+		   0.99   0.416
+	!f1 (micro=0.422, macro=0.703):
 		  False    True
 		-------  ------
-		  0.378   0.989
-	accuracy (micro=0.979, macro=0.979):
+		  0.416    0.99
+	accuracy (micro=0.981, macro=0.981):
 		  False    True
 		-------  ------
-		  0.979   0.979
-	fpr (micro=0.403, macro=0.212):
+		  0.981   0.981
+	fpr (micro=0.371, macro=0.195):
 		  False    True
 		-------  ------
-		  0.407   0.017
-	roc_auc (micro=0.943, macro=0.943):
+		  0.375   0.015
+	roc_auc (micro=0.964, macro=0.963):
 		  False    True
 		-------  ------
-		  0.943   0.943
-	pr_auc (micro=0.993, macro=0.7):
+		  0.964   0.962
+	pr_auc (micro=0.994, macro=0.737):
 		  False    True
 		-------  ------
-		  0.999     0.4
+		      1   0.475
 	
-	 - score_schema: {'title': 'Scikit learn-based classifier score with probability', 'type': 'object', 'properties': {'probability': {'type': 'object', 'description': 'A mapping of probabilities onto each of the potential output labels', 'properties': {'false': {'type': 'number'}, 'true': {'type': 'number'}}}, 'prediction': {'type': 'boolean', 'description': 'The most likely label predicted by the estimator'}}}
+	 - score_schema: {'title': 'Scikit learn-based classifier score with probability', 'type': 'object', 'properties': {'probability': {'type': 'object', 'description': 'A mapping of probabilities onto each of the potential output labels', 'properties': {'true': {'type': 'number'}, 'false': {'type': 'number'}}}, 'prediction': {'type': 'boolean', 'description': 'The most likely label predicted by the estimator'}}}
 

--- a/model_info/huwiki.goodfaith.md
+++ b/model_info/huwiki.goodfaith.md
@@ -1,12 +1,12 @@
 Model Information:
 	 - type: GradientBoosting
-	 - version: 0.5.0
-	 - params: {'min_samples_split': 2, 'max_features': 'log2', 'presort': 'auto', 'min_samples_leaf': 1, 'verbose': 0, 'min_impurity_split': None, 'loss': 'deviance', 'min_weight_fraction_leaf': 0.0, 'warm_start': False, 'max_leaf_nodes': None, 'init': None, 'min_impurity_decrease': 0.0, 'subsample': 1.0, 'random_state': None, 'center': True, 'scale': True, 'n_estimators': 700, 'max_depth': 7, 'multilabel': False, 'label_weights': OrderedDict([(False, 10)]), 'population_rates': None, 'criterion': 'friedman_mse', 'labels': [True, False], 'learning_rate': 0.1}
+	 - version: 0.5.1
+	 - params: {'min_impurity_decrease': 0.0, 'population_rates': None, 'multilabel': False, 'min_weight_fraction_leaf': 0.0, 'verbose': 0, 'loss': 'deviance', 'max_depth': 5, 'max_features': 'log2', 'n_estimators': 500, 'subsample': 1.0, 'learning_rate': 0.01, 'scale': True, 'init': None, 'random_state': None, 'max_leaf_nodes': None, 'min_samples_leaf': 1, 'presort': 'auto', 'label_weights': OrderedDict([(False, 10)]), 'criterion': 'friedman_mse', 'labels': [True, False], 'min_impurity_split': None, 'center': True, 'warm_start': False, 'min_samples_split': 2}
 	Environment:
-	 - revscoring_version: '2.3.4'
-	 - platform: 'Linux-4.9.0-8-amd64-x86_64-with-debian-9.5'
+	 - revscoring_version: '2.4.0'
+	 - platform: 'Linux-4.9.0-9-amd64-x86_64-with-debian-9.9'
 	 - machine: 'x86_64'
-	 - version: '#1 SMP Debian 4.9.110-3+deb9u6 (2018-10-08)'
+	 - version: '#1 SMP Debian 4.9.168-1+deb9u2 (2019-05-13)'
 	 - system: 'Linux'
 	 - processor: ''
 	 - python_build: ('default', 'Sep 27 2018 17:25:39')
@@ -15,67 +15,67 @@ Model Information:
 	 - python_implementation: 'CPython'
 	 - python_revision: ''
 	 - python_version: '3.5.3'
-	 - release: '4.9.0-8-amd64'
+	 - release: '4.9.0-9-amd64'
 	
 	Statistics:
-	counts (n=37755):
+	counts (n=37729):
 		label        n         ~True    ~False
 		-------  -----  ---  -------  --------
-		True     37445  -->    37408        37
-		False      310  -->      247        63
+		True     37427  -->    36945       482
+		False      302  -->      118       184
 	rates:
 		              True    False
 		----------  ------  -------
 		sample       0.992    0.008
 		population   0.992    0.008
-	match_rate (micro=0.99, macro=0.5):
+	match_rate (micro=0.975, macro=0.5):
 		  False    True
 		-------  ------
-		  0.003   0.997
-	filter_rate (micro=0.01, macro=0.5):
+		  0.018   0.982
+	filter_rate (micro=0.025, macro=0.5):
 		  False    True
 		-------  ------
-		  0.997   0.003
-	recall (micro=0.993, macro=0.601):
+		  0.982   0.018
+	recall (micro=0.984, macro=0.798):
 		  False    True
 		-------  ------
-		  0.203   0.999
-	!recall (micro=0.209, macro=0.601):
+		  0.609   0.987
+	!recall (micro=0.612, macro=0.798):
 		  False    True
 		-------  ------
-		  0.999   0.203
-	precision (micro=0.991, macro=0.806):
+		  0.987   0.609
+	precision (micro=0.991, macro=0.634):
 		  False    True
 		-------  ------
-		  0.617   0.994
-	!precision (micro=0.62, macro=0.806):
+		  0.271   0.997
+	!precision (micro=0.276, macro=0.634):
 		  False    True
 		-------  ------
-		  0.994   0.617
-	f1 (micro=0.991, macro=0.651):
+		  0.997   0.271
+	f1 (micro=0.987, macro=0.683):
 		  False    True
 		-------  ------
-		  0.306   0.996
-	!f1 (micro=0.311, macro=0.651):
+		  0.375   0.992
+	!f1 (micro=0.38, macro=0.683):
 		  False    True
 		-------  ------
-		  0.996   0.306
-	accuracy (micro=0.993, macro=0.993):
+		  0.992   0.375
+	accuracy (micro=0.984, macro=0.984):
 		  False    True
 		-------  ------
-		  0.993   0.993
-	fpr (micro=0.791, macro=0.399):
+		  0.984   0.984
+	fpr (micro=0.388, macro=0.202):
 		  False    True
 		-------  ------
-		  0.001   0.797
-	roc_auc (micro=0.988, macro=0.912):
+		  0.013   0.391
+	roc_auc (micro=0.961, macro=0.961):
 		  False    True
 		-------  ------
-		  0.835   0.989
-	pr_auc (micro=0.993, macro=0.688):
+		   0.96   0.961
+	pr_auc (micro=0.995, macro=0.724):
 		  False    True
 		-------  ------
-		  0.379   0.997
+		  0.447       1
 	
-	 - score_schema: {'properties': {'probability': {'properties': {'false': {'type': 'number'}, 'true': {'type': 'number'}}, 'type': 'object', 'description': 'A mapping of probabilities onto each of the potential output labels'}, 'prediction': {'type': 'boolean', 'description': 'The most likely label predicted by the estimator'}}, 'type': 'object', 'title': 'Scikit learn-based classifier score with probability'}
+	 - score_schema: {'title': 'Scikit learn-based classifier score with probability', 'type': 'object', 'properties': {'probability': {'type': 'object', 'description': 'A mapping of probabilities onto each of the potential output labels', 'properties': {'true': {'type': 'number'}, 'false': {'type': 'number'}}}, 'prediction': {'type': 'boolean', 'description': 'The most likely label predicted by the estimator'}}}
 

--- a/models/huwiki.damaging.gradient_boosting.model
+++ b/models/huwiki.damaging.gradient_boosting.model
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a67b4bbde2d5f97f19fa5a747bde6d9c6db5e37d791213ed803010471b25eb85
-size 2485018
+oid sha256:1fbae9822835cabbb449e4cb940a764ea1b2a83b8d1f22ad9039ac08fec654be
+size 2502351

--- a/models/huwiki.goodfaith.gradient_boosting.model
+++ b/models/huwiki.goodfaith.gradient_boosting.model
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1984c8e8eb941a117b8e3035cdb626da0a439d8b40221e6b10de389bd3584e45
-size 6659235
+oid sha256:223d6d359cf790fec40976bd2a20918878abfdef52ddb103a128145cebb2ca07
+size 2430893

--- a/tuning_reports/huwiki.damaging.md
+++ b/tuning_reports/huwiki.damaging.md
@@ -1,181 +1,442 @@
 # Model tuning report
-- Revscoring version: 2.1.0
+- Revscoring version: 2.4.0
 - Features: editquality.feature_lists.huwiki.damaging
-- Date: 2018-04-10T12:15:14.615726
-- Observations: 39674
+- Date: 2019-07-23T00:16:44.934365
+- Observations: 37729
 - Labels: [true, false]
 - Statistic: roc_auc.labels.true (maximize)
 - Folds: 5
 
 # Top scoring configurations
-| model            |   roc_auc.labels.true | params                                                                 |
-|:-----------------|----------------------:|:-----------------------------------------------------------------------|
-| GradientBoosting |                0.9351 | learning_rate=0.01, max_features="log2", max_depth=5, n_estimators=500 |
-| GradientBoosting |                0.9344 | learning_rate=0.01, max_features="log2", max_depth=5, n_estimators=700 |
-| GradientBoosting |                0.9335 | learning_rate=0.1, max_features="log2", max_depth=3, n_estimators=300  |
-| GradientBoosting |                0.9333 | learning_rate=0.1, max_features="log2", max_depth=3, n_estimators=100  |
-| GradientBoosting |                0.9332 | learning_rate=0.01, max_features="log2", max_depth=3, n_estimators=700 |
-| GradientBoosting |                0.9328 | learning_rate=0.1, max_features="log2", max_depth=5, n_estimators=100  |
-| GradientBoosting |                0.9327 | learning_rate=0.01, max_features="log2", max_depth=3, n_estimators=500 |
-| GradientBoosting |                0.9326 | learning_rate=0.01, max_features="log2", max_depth=7, n_estimators=500 |
-| GradientBoosting |                0.9325 | learning_rate=0.1, max_features="log2", max_depth=1, n_estimators=500  |
-| GradientBoosting |                0.9323 | learning_rate=0.01, max_features="log2", max_depth=7, n_estimators=300 |
+| model              |   roc_auc.labels.true | params                                                                                     |
+|:-------------------|----------------------:|:-------------------------------------------------------------------------------------------|
+| GradientBoosting   |                0.9649 | max_features="log2", min_samples_leaf=1, learning_rate=0.1, max_depth=1, n_estimators=700  |
+| GradientBoosting   |                0.9643 | max_features="log2", min_samples_leaf=7, learning_rate=0.1, max_depth=3, n_estimators=100  |
+| GradientBoosting   |                0.9639 | max_features="log2", min_samples_leaf=5, learning_rate=0.1, max_depth=1, n_estimators=700  |
+| LogisticRegression |                0.9638 | penalty="l1", C=1                                                                          |
+| GradientBoosting   |                0.9638 | max_features="log2", min_samples_leaf=3, learning_rate=0.1, max_depth=1, n_estimators=700  |
+| GradientBoosting   |                0.9636 | max_features="log2", min_samples_leaf=1, learning_rate=0.1, max_depth=1, n_estimators=500  |
+| GradientBoosting   |                0.9634 | max_features="log2", min_samples_leaf=5, learning_rate=0.1, max_depth=1, n_estimators=500  |
+| GradientBoosting   |                0.9632 | max_features="log2", min_samples_leaf=7, learning_rate=0.1, max_depth=1, n_estimators=700  |
+| GradientBoosting   |                0.9632 | max_features="log2", min_samples_leaf=13, learning_rate=0.1, max_depth=1, n_estimators=700 |
+| GradientBoosting   |                0.963  | max_features="log2", min_samples_leaf=3, learning_rate=0.1, max_depth=1, n_estimators=500  |
 
 # Models
-## LogisticRegression
-|   roc_auc.labels.true | params              |
-|----------------------:|:--------------------|
-|                0.9194 | penalty="l1", C=10  |
-|                0.9193 | penalty="l1", C=1   |
-|                0.9161 | penalty="l1", C=0.1 |
-|                0.7768 | penalty="l2", C=1   |
-|                0.774  | penalty="l2", C=0.1 |
-|                0.7635 | penalty="l2", C=10  |
-
-## GradientBoosting
-|   roc_auc.labels.true | params                                                                 |
-|----------------------:|:-----------------------------------------------------------------------|
-|                0.9351 | learning_rate=0.01, max_features="log2", max_depth=5, n_estimators=500 |
-|                0.9344 | learning_rate=0.01, max_features="log2", max_depth=5, n_estimators=700 |
-|                0.9335 | learning_rate=0.1, max_features="log2", max_depth=3, n_estimators=300  |
-|                0.9333 | learning_rate=0.1, max_features="log2", max_depth=3, n_estimators=100  |
-|                0.9332 | learning_rate=0.01, max_features="log2", max_depth=3, n_estimators=700 |
-|                0.9328 | learning_rate=0.1, max_features="log2", max_depth=5, n_estimators=100  |
-|                0.9327 | learning_rate=0.01, max_features="log2", max_depth=3, n_estimators=500 |
-|                0.9326 | learning_rate=0.01, max_features="log2", max_depth=7, n_estimators=500 |
-|                0.9325 | learning_rate=0.1, max_features="log2", max_depth=1, n_estimators=500  |
-|                0.9323 | learning_rate=0.01, max_features="log2", max_depth=7, n_estimators=300 |
-|                0.9322 | learning_rate=0.01, max_features="log2", max_depth=7, n_estimators=700 |
-|                0.9321 | learning_rate=0.1, max_features="log2", max_depth=1, n_estimators=300  |
-|                0.9315 | learning_rate=0.01, max_features="log2", max_depth=5, n_estimators=300 |
-|                0.9315 | learning_rate=0.1, max_features="log2", max_depth=1, n_estimators=700  |
-|                0.929  | learning_rate=0.1, max_features="log2", max_depth=3, n_estimators=500  |
-|                0.9285 | learning_rate=0.01, max_features="log2", max_depth=7, n_estimators=100 |
-|                0.9261 | learning_rate=0.01, max_features="log2", max_depth=3, n_estimators=300 |
-|                0.9257 | learning_rate=0.1, max_features="log2", max_depth=3, n_estimators=700  |
-|                0.9253 | learning_rate=0.5, max_features="log2", max_depth=1, n_estimators=300  |
-|                0.9251 | learning_rate=0.5, max_features="log2", max_depth=1, n_estimators=500  |
-|                0.925  | learning_rate=0.5, max_features="log2", max_depth=1, n_estimators=100  |
-|                0.9245 | learning_rate=0.01, max_features="log2", max_depth=5, n_estimators=100 |
-|                0.9242 | learning_rate=0.1, max_features="log2", max_depth=7, n_estimators=100  |
-|                0.9217 | learning_rate=0.5, max_features="log2", max_depth=1, n_estimators=700  |
-|                0.9216 | learning_rate=0.1, max_features="log2", max_depth=1, n_estimators=100  |
-|                0.9212 | learning_rate=0.1, max_features="log2", max_depth=5, n_estimators=300  |
-|                0.9196 | learning_rate=0.01, max_features="log2", max_depth=1, n_estimators=700 |
-|                0.9169 | learning_rate=0.01, max_features="log2", max_depth=3, n_estimators=100 |
-|                0.9168 | learning_rate=0.5, max_features="log2", max_depth=3, n_estimators=100  |
-|                0.9151 | learning_rate=0.01, max_features="log2", max_depth=1, n_estimators=500 |
-|                0.9136 | learning_rate=0.1, max_features="log2", max_depth=5, n_estimators=500  |
-|                0.9102 | learning_rate=0.01, max_features="log2", max_depth=1, n_estimators=300 |
-|                0.9005 | learning_rate=0.1, max_features="log2", max_depth=5, n_estimators=700  |
-|                0.8981 | learning_rate=0.1, max_features="log2", max_depth=7, n_estimators=300  |
-|                0.8979 | learning_rate=1, max_features="log2", max_depth=1, n_estimators=100    |
-|                0.8978 | learning_rate=0.01, max_features="log2", max_depth=1, n_estimators=100 |
-|                0.8905 | learning_rate=0.5, max_features="log2", max_depth=3, n_estimators=300  |
-|                0.8871 | learning_rate=0.5, max_features="log2", max_depth=5, n_estimators=100  |
-|                0.8543 | learning_rate=1, max_features="log2", max_depth=3, n_estimators=100    |
-|                0.8491 | learning_rate=0.1, max_features="log2", max_depth=7, n_estimators=500  |
-|                0.8463 | learning_rate=1, max_features="log2", max_depth=1, n_estimators=300    |
-|                0.8358 | learning_rate=0.5, max_features="log2", max_depth=3, n_estimators=700  |
-|                0.8306 | learning_rate=0.5, max_features="log2", max_depth=3, n_estimators=500  |
-|                0.8222 | learning_rate=1, max_features="log2", max_depth=1, n_estimators=700    |
-|                0.8027 | learning_rate=0.5, max_features="log2", max_depth=7, n_estimators=100  |
-|                0.8016 | learning_rate=0.1, max_features="log2", max_depth=7, n_estimators=700  |
-|                0.7918 | learning_rate=0.5, max_features="log2", max_depth=5, n_estimators=300  |
-|                0.7785 | learning_rate=1, max_features="log2", max_depth=3, n_estimators=300    |
-|                0.7717 | learning_rate=0.5, max_features="log2", max_depth=5, n_estimators=500  |
-|                0.7706 | learning_rate=0.5, max_features="log2", max_depth=5, n_estimators=700  |
-|                0.7687 | learning_rate=1, max_features="log2", max_depth=1, n_estimators=500    |
-|                0.7637 | learning_rate=0.5, max_features="log2", max_depth=7, n_estimators=300  |
-|                0.7604 | learning_rate=1, max_features="log2", max_depth=5, n_estimators=100    |
-|                0.7569 | learning_rate=0.5, max_features="log2", max_depth=7, n_estimators=500  |
-|                0.7307 | learning_rate=1, max_features="log2", max_depth=5, n_estimators=300    |
-|                0.7111 | learning_rate=1, max_features="log2", max_depth=3, n_estimators=700    |
-|                0.6823 | learning_rate=0.5, max_features="log2", max_depth=7, n_estimators=700  |
-|                0.6767 | learning_rate=1, max_features="log2", max_depth=7, n_estimators=100    |
-|                0.6571 | learning_rate=1, max_features="log2", max_depth=7, n_estimators=300    |
-|                0.6565 | learning_rate=1, max_features="log2", max_depth=5, n_estimators=700    |
-
-## GaussianNB
-| roc_auc.labels.true   | params   |
-||
-
 ## BernoulliNB
 |   roc_auc.labels.true | params   |
 |----------------------:|:---------|
-|                0.8433 |          |
+|                0.8847 |          |
 
 ## RandomForestClassifier
 |   roc_auc.labels.true | params                                                                          |
 |----------------------:|:--------------------------------------------------------------------------------|
-|                0.9317 | criterion="entropy", max_features="log2", n_estimators=640, min_samples_leaf=13 |
-|                0.9305 | criterion="entropy", max_features="log2", n_estimators=80, min_samples_leaf=13  |
-|                0.9305 | criterion="entropy", max_features="log2", n_estimators=640, min_samples_leaf=7  |
-|                0.9303 | criterion="entropy", max_features="log2", n_estimators=640, min_samples_leaf=3  |
-|                0.9301 | criterion="entropy", max_features="log2", n_estimators=160, min_samples_leaf=13 |
-|                0.9298 | criterion="entropy", max_features="log2", n_estimators=320, min_samples_leaf=7  |
-|                0.9296 | criterion="entropy", max_features="log2", n_estimators=80, min_samples_leaf=7   |
-|                0.9296 | criterion="entropy", max_features="log2", n_estimators=320, min_samples_leaf=13 |
-|                0.9295 | criterion="gini", max_features="log2", n_estimators=320, min_samples_leaf=7     |
-|                0.9291 | criterion="entropy", max_features="log2", n_estimators=640, min_samples_leaf=1  |
-|                0.9288 | criterion="entropy", max_features="log2", n_estimators=320, min_samples_leaf=3  |
-|                0.9287 | criterion="entropy", max_features="log2", n_estimators=160, min_samples_leaf=5  |
-|                0.9284 | criterion="entropy", max_features="log2", n_estimators=320, min_samples_leaf=5  |
-|                0.9282 | criterion="entropy", max_features="log2", n_estimators=160, min_samples_leaf=7  |
-|                0.9282 | criterion="entropy", max_features="log2", n_estimators=640, min_samples_leaf=5  |
-|                0.9277 | criterion="gini", max_features="log2", n_estimators=640, min_samples_leaf=13    |
-|                0.9277 | criterion="entropy", max_features="log2", n_estimators=160, min_samples_leaf=3  |
-|                0.9276 | criterion="gini", max_features="log2", n_estimators=640, min_samples_leaf=5     |
-|                0.9272 | criterion="gini", max_features="log2", n_estimators=320, min_samples_leaf=13    |
-|                0.9269 | criterion="entropy", max_features="log2", n_estimators=40, min_samples_leaf=7   |
-|                0.9267 | criterion="entropy", max_features="log2", n_estimators=40, min_samples_leaf=13  |
-|                0.9262 | criterion="gini", max_features="log2", n_estimators=640, min_samples_leaf=7     |
-|                0.926  | criterion="gini", max_features="log2", n_estimators=80, min_samples_leaf=13     |
-|                0.9258 | criterion="gini", max_features="log2", n_estimators=160, min_samples_leaf=7     |
-|                0.9253 | criterion="gini", max_features="log2", n_estimators=160, min_samples_leaf=13    |
-|                0.9252 | criterion="gini", max_features="log2", n_estimators=160, min_samples_leaf=5     |
-|                0.925  | criterion="gini", max_features="log2", n_estimators=640, min_samples_leaf=3     |
-|                0.9248 | criterion="gini", max_features="log2", n_estimators=320, min_samples_leaf=5     |
-|                0.9247 | criterion="gini", max_features="log2", n_estimators=640, min_samples_leaf=1     |
-|                0.9245 | criterion="gini", max_features="log2", n_estimators=320, min_samples_leaf=3     |
-|                0.9245 | criterion="entropy", max_features="log2", n_estimators=320, min_samples_leaf=1  |
-|                0.9243 | criterion="entropy", max_features="log2", n_estimators=80, min_samples_leaf=5   |
-|                0.9233 | criterion="gini", max_features="log2", n_estimators=80, min_samples_leaf=7      |
-|                0.9226 | criterion="entropy", max_features="log2", n_estimators=80, min_samples_leaf=3   |
-|                0.9213 | criterion="gini", max_features="log2", n_estimators=80, min_samples_leaf=5      |
-|                0.9202 | criterion="gini", max_features="log2", n_estimators=160, min_samples_leaf=3     |
-|                0.9197 | criterion="gini", max_features="log2", n_estimators=40, min_samples_leaf=13     |
-|                0.9189 | criterion="entropy", max_features="log2", n_estimators=20, min_samples_leaf=7   |
-|                0.9182 | criterion="entropy", max_features="log2", n_estimators=40, min_samples_leaf=5   |
-|                0.9179 | criterion="gini", max_features="log2", n_estimators=20, min_samples_leaf=13     |
-|                0.9175 | criterion="gini", max_features="log2", n_estimators=80, min_samples_leaf=3      |
-|                0.9168 | criterion="gini", max_features="log2", n_estimators=40, min_samples_leaf=7      |
-|                0.9164 | criterion="gini", max_features="log2", n_estimators=320, min_samples_leaf=1     |
-|                0.915  | criterion="entropy", max_features="log2", n_estimators=20, min_samples_leaf=13  |
-|                0.9132 | criterion="gini", max_features="log2", n_estimators=160, min_samples_leaf=1     |
-|                0.911  | criterion="gini", max_features="log2", n_estimators=40, min_samples_leaf=5      |
-|                0.9094 | criterion="entropy", max_features="log2", n_estimators=160, min_samples_leaf=1  |
-|                0.9078 | criterion="gini", max_features="log2", n_estimators=40, min_samples_leaf=3      |
-|                0.907  | criterion="gini", max_features="log2", n_estimators=10, min_samples_leaf=13     |
-|                0.9069 | criterion="entropy", max_features="log2", n_estimators=40, min_samples_leaf=3   |
-|                0.9059 | criterion="entropy", max_features="log2", n_estimators=10, min_samples_leaf=13  |
-|                0.9009 | criterion="entropy", max_features="log2", n_estimators=80, min_samples_leaf=1   |
-|                0.8997 | criterion="gini", max_features="log2", n_estimators=20, min_samples_leaf=5      |
-|                0.8993 | criterion="gini", max_features="log2", n_estimators=80, min_samples_leaf=1      |
-|                0.8983 | criterion="gini", max_features="log2", n_estimators=20, min_samples_leaf=7      |
-|                0.898  | criterion="entropy", max_features="log2", n_estimators=20, min_samples_leaf=3   |
-|                0.8958 | criterion="entropy", max_features="log2", n_estimators=20, min_samples_leaf=5   |
-|                0.8929 | criterion="gini", max_features="log2", n_estimators=20, min_samples_leaf=3      |
-|                0.8884 | criterion="gini", max_features="log2", n_estimators=10, min_samples_leaf=7      |
-|                0.882  | criterion="entropy", max_features="log2", n_estimators=40, min_samples_leaf=1   |
-|                0.8817 | criterion="entropy", max_features="log2", n_estimators=10, min_samples_leaf=7   |
-|                0.8808 | criterion="gini", max_features="log2", n_estimators=10, min_samples_leaf=5      |
-|                0.8775 | criterion="gini", max_features="log2", n_estimators=40, min_samples_leaf=1      |
-|                0.8758 | criterion="entropy", max_features="log2", n_estimators=10, min_samples_leaf=5   |
-|                0.8637 | criterion="entropy", max_features="log2", n_estimators=10, min_samples_leaf=3   |
-|                0.8494 | criterion="gini", max_features="log2", n_estimators=10, min_samples_leaf=3      |
-|                0.8425 | criterion="entropy", max_features="log2", n_estimators=20, min_samples_leaf=1   |
-|                0.8416 | criterion="gini", max_features="log2", n_estimators=20, min_samples_leaf=1      |
-|                0.7924 | criterion="entropy", max_features="log2", n_estimators=10, min_samples_leaf=1   |
-|                0.7781 | criterion="gini", max_features="log2", n_estimators=10, min_samples_leaf=1      |
+|                0.9606 | max_features="log2", min_samples_leaf=7, criterion="entropy", n_estimators=640  |
+|                0.9605 | max_features="log2", min_samples_leaf=13, criterion="entropy", n_estimators=640 |
+|                0.96   | max_features="log2", min_samples_leaf=5, criterion="entropy", n_estimators=640  |
+|                0.9599 | max_features="log2", min_samples_leaf=7, criterion="entropy", n_estimators=320  |
+|                0.9598 | max_features="log2", min_samples_leaf=13, criterion="entropy", n_estimators=320 |
+|                0.9589 | max_features="log2", min_samples_leaf=13, criterion="entropy", n_estimators=160 |
+|                0.958  | max_features="log2", min_samples_leaf=3, criterion="entropy", n_estimators=640  |
+|                0.9578 | max_features="log2", min_samples_leaf=7, criterion="entropy", n_estimators=160  |
+|                0.9576 | max_features="log2", min_samples_leaf=5, criterion="entropy", n_estimators=320  |
+|                0.9563 | max_features="log2", min_samples_leaf=7, criterion="gini", n_estimators=320     |
+|                0.9563 | max_features="log2", min_samples_leaf=13, criterion="gini", n_estimators=320    |
+|                0.956  | max_features="log2", min_samples_leaf=13, criterion="entropy", n_estimators=40  |
+|                0.956  | max_features="log2", min_samples_leaf=13, criterion="entropy", n_estimators=80  |
+|                0.9554 | max_features="log2", min_samples_leaf=5, criterion="entropy", n_estimators=80   |
+|                0.9554 | max_features="log2", min_samples_leaf=3, criterion="entropy", n_estimators=320  |
+|                0.9553 | max_features="log2", min_samples_leaf=7, criterion="gini", n_estimators=640     |
+|                0.9551 | max_features="log2", min_samples_leaf=7, criterion="entropy", n_estimators=80   |
+|                0.955  | max_features="log2", min_samples_leaf=3, criterion="gini", n_estimators=640     |
+|                0.9549 | max_features="log2", min_samples_leaf=13, criterion="gini", n_estimators=640    |
+|                0.9537 | max_features="log2", min_samples_leaf=5, criterion="entropy", n_estimators=160  |
+|                0.9528 | max_features="log2", min_samples_leaf=3, criterion="entropy", n_estimators=160  |
+|                0.9527 | max_features="log2", min_samples_leaf=5, criterion="gini", n_estimators=640     |
+|                0.9523 | max_features="log2", min_samples_leaf=13, criterion="gini", n_estimators=80     |
+|                0.9522 | max_features="log2", min_samples_leaf=1, criterion="entropy", n_estimators=640  |
+|                0.9515 | max_features="log2", min_samples_leaf=7, criterion="gini", n_estimators=160     |
+|                0.951  | max_features="log2", min_samples_leaf=5, criterion="gini", n_estimators=320     |
+|                0.951  | max_features="log2", min_samples_leaf=3, criterion="gini", n_estimators=320     |
+|                0.9508 | max_features="log2", min_samples_leaf=1, criterion="entropy", n_estimators=320  |
+|                0.9507 | max_features="log2", min_samples_leaf=13, criterion="gini", n_estimators=160    |
+|                0.9502 | max_features="log2", min_samples_leaf=13, criterion="gini", n_estimators=40     |
+|                0.9496 | max_features="log2", min_samples_leaf=5, criterion="gini", n_estimators=160     |
+|                0.9487 | max_features="log2", min_samples_leaf=7, criterion="entropy", n_estimators=20   |
+|                0.9484 | max_features="log2", min_samples_leaf=7, criterion="gini", n_estimators=80      |
+|                0.9473 | max_features="log2", min_samples_leaf=13, criterion="entropy", n_estimators=20  |
+|                0.9468 | max_features="log2", min_samples_leaf=3, criterion="entropy", n_estimators=80   |
+|                0.9463 | max_features="log2", min_samples_leaf=1, criterion="gini", n_estimators=640     |
+|                0.946  | max_features="log2", min_samples_leaf=7, criterion="entropy", n_estimators=40   |
+|                0.9451 | max_features="log2", min_samples_leaf=7, criterion="gini", n_estimators=40      |
+|                0.9444 | max_features="log2", min_samples_leaf=3, criterion="gini", n_estimators=160     |
+|                0.9434 | max_features="log2", min_samples_leaf=5, criterion="gini", n_estimators=80      |
+|                0.9427 | max_features="log2", min_samples_leaf=5, criterion="entropy", n_estimators=40   |
+|                0.9424 | max_features="log2", min_samples_leaf=1, criterion="entropy", n_estimators=160  |
+|                0.941  | max_features="log2", min_samples_leaf=3, criterion="gini", n_estimators=80      |
+|                0.94   | max_features="log2", min_samples_leaf=13, criterion="entropy", n_estimators=10  |
+|                0.9389 | max_features="log2", min_samples_leaf=5, criterion="gini", n_estimators=40      |
+|                0.9369 | max_features="log2", min_samples_leaf=1, criterion="gini", n_estimators=320     |
+|                0.9366 | max_features="log2", min_samples_leaf=7, criterion="gini", n_estimators=20      |
+|                0.9365 | max_features="log2", min_samples_leaf=3, criterion="entropy", n_estimators=40   |
+|                0.9336 | max_features="log2", min_samples_leaf=1, criterion="gini", n_estimators=160     |
+|                0.9313 | max_features="log2", min_samples_leaf=3, criterion="gini", n_estimators=40      |
+|                0.9311 | max_features="log2", min_samples_leaf=5, criterion="gini", n_estimators=20      |
+|                0.9311 | max_features="log2", min_samples_leaf=13, criterion="gini", n_estimators=20     |
+|                0.9296 | max_features="log2", min_samples_leaf=5, criterion="entropy", n_estimators=20   |
+|                0.9283 | max_features="log2", min_samples_leaf=3, criterion="entropy", n_estimators=20   |
+|                0.9281 | max_features="log2", min_samples_leaf=7, criterion="gini", n_estimators=10      |
+|                0.928  | max_features="log2", min_samples_leaf=13, criterion="gini", n_estimators=10     |
+|                0.927  | max_features="log2", min_samples_leaf=1, criterion="entropy", n_estimators=80   |
+|                0.9256 | max_features="log2", min_samples_leaf=7, criterion="entropy", n_estimators=10   |
+|                0.9245 | max_features="log2", min_samples_leaf=3, criterion="gini", n_estimators=20      |
+|                0.9227 | max_features="log2", min_samples_leaf=1, criterion="gini", n_estimators=80      |
+|                0.9212 | max_features="log2", min_samples_leaf=5, criterion="entropy", n_estimators=10   |
+|                0.912  | max_features="log2", min_samples_leaf=1, criterion="entropy", n_estimators=40   |
+|                0.9112 | max_features="log2", min_samples_leaf=5, criterion="gini", n_estimators=10      |
+|                0.9094 | max_features="log2", min_samples_leaf=1, criterion="gini", n_estimators=40      |
+|                0.9013 | max_features="log2", min_samples_leaf=3, criterion="entropy", n_estimators=10   |
+|                0.8977 | max_features="log2", min_samples_leaf=3, criterion="gini", n_estimators=10      |
+|                0.8909 | max_features="log2", min_samples_leaf=1, criterion="gini", n_estimators=20      |
+|                0.888  | max_features="log2", min_samples_leaf=1, criterion="entropy", n_estimators=20   |
+|                0.8496 | max_features="log2", min_samples_leaf=1, criterion="entropy", n_estimators=10   |
+|                0.8491 | max_features="log2", min_samples_leaf=1, criterion="gini", n_estimators=10      |
+
+## LogisticRegression
+|   roc_auc.labels.true | params              |
+|----------------------:|:--------------------|
+|                0.9638 | penalty="l1", C=1   |
+|                0.962  | penalty="l1", C=10  |
+|                0.96   | penalty="l1", C=0.1 |
+|                0.8282 | penalty="l2", C=10  |
+|                0.8225 | penalty="l2", C=1   |
+|                0.8209 | penalty="l2", C=0.1 |
+
+## GaussianNB
+|   roc_auc.labels.true | params   |
+|----------------------:|:---------|
+|                 0.958 |          |
+
+## GradientBoosting
+|   roc_auc.labels.true | params                                                                                      |
+|----------------------:|:--------------------------------------------------------------------------------------------|
+|                0.9649 | max_features="log2", min_samples_leaf=1, learning_rate=0.1, max_depth=1, n_estimators=700   |
+|                0.9643 | max_features="log2", min_samples_leaf=7, learning_rate=0.1, max_depth=3, n_estimators=100   |
+|                0.9639 | max_features="log2", min_samples_leaf=5, learning_rate=0.1, max_depth=1, n_estimators=700   |
+|                0.9638 | max_features="log2", min_samples_leaf=3, learning_rate=0.1, max_depth=1, n_estimators=700   |
+|                0.9636 | max_features="log2", min_samples_leaf=1, learning_rate=0.1, max_depth=1, n_estimators=500   |
+|                0.9634 | max_features="log2", min_samples_leaf=5, learning_rate=0.1, max_depth=1, n_estimators=500   |
+|                0.9632 | max_features="log2", min_samples_leaf=7, learning_rate=0.1, max_depth=1, n_estimators=700   |
+|                0.9632 | max_features="log2", min_samples_leaf=13, learning_rate=0.1, max_depth=1, n_estimators=700  |
+|                0.963  | max_features="log2", min_samples_leaf=3, learning_rate=0.1, max_depth=1, n_estimators=500   |
+|                0.9629 | max_features="log2", min_samples_leaf=7, learning_rate=0.01, max_depth=5, n_estimators=700  |
+|                0.9629 | max_features="log2", min_samples_leaf=7, learning_rate=0.1, max_depth=1, n_estimators=500   |
+|                0.9628 | max_features="log2", min_samples_leaf=3, learning_rate=0.01, max_depth=5, n_estimators=700  |
+|                0.9628 | max_features="log2", min_samples_leaf=13, learning_rate=0.1, max_depth=1, n_estimators=500  |
+|                0.9625 | max_features="log2", min_samples_leaf=13, learning_rate=0.01, max_depth=5, n_estimators=700 |
+|                0.9623 | max_features="log2", min_samples_leaf=5, learning_rate=0.01, max_depth=5, n_estimators=700  |
+|                0.9623 | max_features="log2", min_samples_leaf=13, learning_rate=0.1, max_depth=3, n_estimators=100  |
+|                0.9621 | max_features="log2", min_samples_leaf=1, learning_rate=0.1, max_depth=3, n_estimators=100   |
+|                0.962  | max_features="log2", min_samples_leaf=1, learning_rate=0.01, max_depth=5, n_estimators=700  |
+|                0.9616 | max_features="log2", min_samples_leaf=13, learning_rate=0.01, max_depth=7, n_estimators=700 |
+|                0.9615 | max_features="log2", min_samples_leaf=1, learning_rate=0.5, max_depth=1, n_estimators=300   |
+|                0.9612 | max_features="log2", min_samples_leaf=5, learning_rate=0.01, max_depth=7, n_estimators=500  |
+|                0.9612 | max_features="log2", min_samples_leaf=7, learning_rate=0.01, max_depth=7, n_estimators=700  |
+|                0.9611 | max_features="log2", min_samples_leaf=13, learning_rate=0.01, max_depth=7, n_estimators=500 |
+|                0.9611 | max_features="log2", min_samples_leaf=3, learning_rate=0.01, max_depth=7, n_estimators=700  |
+|                0.961  | max_features="log2", min_samples_leaf=1, learning_rate=0.1, max_depth=1, n_estimators=300   |
+|                0.961  | max_features="log2", min_samples_leaf=7, learning_rate=0.1, max_depth=5, n_estimators=100   |
+|                0.9609 | max_features="log2", min_samples_leaf=5, learning_rate=0.01, max_depth=5, n_estimators=500  |
+|                0.9609 | max_features="log2", min_samples_leaf=13, learning_rate=0.01, max_depth=5, n_estimators=500 |
+|                0.9609 | max_features="log2", min_samples_leaf=3, learning_rate=0.1, max_depth=1, n_estimators=300   |
+|                0.9607 | max_features="log2", min_samples_leaf=5, learning_rate=0.01, max_depth=7, n_estimators=700  |
+|                0.9607 | max_features="log2", min_samples_leaf=3, learning_rate=0.01, max_depth=7, n_estimators=500  |
+|                0.9607 | max_features="log2", min_samples_leaf=3, learning_rate=0.01, max_depth=5, n_estimators=500  |
+|                0.9606 | max_features="log2", min_samples_leaf=3, learning_rate=0.1, max_depth=3, n_estimators=300   |
+|                0.9606 | max_features="log2", min_samples_leaf=13, learning_rate=0.1, max_depth=1, n_estimators=300  |
+|                0.9606 | max_features="log2", min_samples_leaf=1, learning_rate=0.01, max_depth=7, n_estimators=700  |
+|                0.9605 | max_features="log2", min_samples_leaf=3, learning_rate=0.01, max_depth=3, n_estimators=700  |
+|                0.9603 | max_features="log2", min_samples_leaf=1, learning_rate=0.01, max_depth=5, n_estimators=500  |
+|                0.9603 | max_features="log2", min_samples_leaf=7, learning_rate=0.1, max_depth=1, n_estimators=300   |
+|                0.9603 | max_features="log2", min_samples_leaf=13, learning_rate=0.1, max_depth=5, n_estimators=100  |
+|                0.9603 | max_features="log2", min_samples_leaf=13, learning_rate=0.1, max_depth=3, n_estimators=300  |
+|                0.9603 | max_features="log2", min_samples_leaf=7, learning_rate=0.1, max_depth=3, n_estimators=300   |
+|                0.9603 | max_features="log2", min_samples_leaf=13, learning_rate=0.5, max_depth=1, n_estimators=100  |
+|                0.9602 | max_features="log2", min_samples_leaf=13, learning_rate=0.01, max_depth=3, n_estimators=700 |
+|                0.9601 | max_features="log2", min_samples_leaf=13, learning_rate=0.5, max_depth=1, n_estimators=300  |
+|                0.9601 | max_features="log2", min_samples_leaf=1, learning_rate=0.1, max_depth=5, n_estimators=100   |
+|                0.9601 | max_features="log2", min_samples_leaf=3, learning_rate=0.1, max_depth=5, n_estimators=100   |
+|                0.9601 | max_features="log2", min_samples_leaf=7, learning_rate=0.01, max_depth=7, n_estimators=500  |
+|                0.96   | max_features="log2", min_samples_leaf=7, learning_rate=0.01, max_depth=3, n_estimators=700  |
+|                0.96   | max_features="log2", min_samples_leaf=5, learning_rate=0.1, max_depth=1, n_estimators=300   |
+|                0.9599 | max_features="log2", min_samples_leaf=1, learning_rate=0.5, max_depth=1, n_estimators=100   |
+|                0.9598 | max_features="log2", min_samples_leaf=7, learning_rate=0.01, max_depth=5, n_estimators=500  |
+|                0.9598 | max_features="log2", min_samples_leaf=5, learning_rate=0.5, max_depth=1, n_estimators=300   |
+|                0.9598 | max_features="log2", min_samples_leaf=13, learning_rate=0.01, max_depth=7, n_estimators=300 |
+|                0.9597 | max_features="log2", min_samples_leaf=5, learning_rate=0.01, max_depth=3, n_estimators=700  |
+|                0.9597 | max_features="log2", min_samples_leaf=1, learning_rate=0.01, max_depth=3, n_estimators=700  |
+|                0.9596 | max_features="log2", min_samples_leaf=5, learning_rate=0.1, max_depth=3, n_estimators=100   |
+|                0.9595 | max_features="log2", min_samples_leaf=13, learning_rate=0.1, max_depth=3, n_estimators=500  |
+|                0.9595 | max_features="log2", min_samples_leaf=5, learning_rate=0.1, max_depth=5, n_estimators=100   |
+|                0.9594 | max_features="log2", min_samples_leaf=5, learning_rate=0.1, max_depth=3, n_estimators=300   |
+|                0.9593 | max_features="log2", min_samples_leaf=7, learning_rate=0.5, max_depth=1, n_estimators=300   |
+|                0.9592 | max_features="log2", min_samples_leaf=13, learning_rate=0.01, max_depth=5, n_estimators=300 |
+|                0.9591 | max_features="log2", min_samples_leaf=3, learning_rate=0.5, max_depth=1, n_estimators=500   |
+|                0.9591 | max_features="log2", min_samples_leaf=5, learning_rate=0.01, max_depth=3, n_estimators=500  |
+|                0.9591 | max_features="log2", min_samples_leaf=3, learning_rate=0.01, max_depth=3, n_estimators=500  |
+|                0.9589 | max_features="log2", min_samples_leaf=3, learning_rate=0.1, max_depth=3, n_estimators=500   |
+|                0.9588 | max_features="log2", min_samples_leaf=7, learning_rate=0.01, max_depth=7, n_estimators=300  |
+|                0.9587 | max_features="log2", min_samples_leaf=3, learning_rate=0.5, max_depth=1, n_estimators=300   |
+|                0.9587 | max_features="log2", min_samples_leaf=3, learning_rate=0.1, max_depth=3, n_estimators=100   |
+|                0.9587 | max_features="log2", min_samples_leaf=1, learning_rate=0.01, max_depth=3, n_estimators=500  |
+|                0.9586 | max_features="log2", min_samples_leaf=1, learning_rate=0.01, max_depth=7, n_estimators=500  |
+|                0.9585 | max_features="log2", min_samples_leaf=5, learning_rate=0.01, max_depth=7, n_estimators=300  |
+|                0.9585 | max_features="log2", min_samples_leaf=5, learning_rate=0.1, max_depth=7, n_estimators=100   |
+|                0.9584 | max_features="log2", min_samples_leaf=3, learning_rate=0.01, max_depth=5, n_estimators=300  |
+|                0.9583 | max_features="log2", min_samples_leaf=7, learning_rate=0.01, max_depth=3, n_estimators=500  |
+|                0.9583 | max_features="log2", min_samples_leaf=7, learning_rate=0.5, max_depth=1, n_estimators=500   |
+|                0.9583 | max_features="log2", min_samples_leaf=3, learning_rate=0.5, max_depth=1, n_estimators=100   |
+|                0.9582 | max_features="log2", min_samples_leaf=7, learning_rate=0.1, max_depth=3, n_estimators=500   |
+|                0.9581 | max_features="log2", min_samples_leaf=13, learning_rate=0.01, max_depth=3, n_estimators=500 |
+|                0.9581 | max_features="log2", min_samples_leaf=5, learning_rate=0.1, max_depth=3, n_estimators=500   |
+|                0.958  | max_features="log2", min_samples_leaf=5, learning_rate=0.01, max_depth=5, n_estimators=300  |
+|                0.958  | max_features="log2", min_samples_leaf=1, learning_rate=0.1, max_depth=3, n_estimators=300   |
+|                0.958  | max_features="log2", min_samples_leaf=3, learning_rate=0.5, max_depth=1, n_estimators=700   |
+|                0.9579 | max_features="log2", min_samples_leaf=1, learning_rate=0.5, max_depth=1, n_estimators=500   |
+|                0.9579 | max_features="log2", min_samples_leaf=1, learning_rate=0.01, max_depth=5, n_estimators=300  |
+|                0.9579 | max_features="log2", min_samples_leaf=1, learning_rate=0.5, max_depth=1, n_estimators=700   |
+|                0.9578 | max_features="log2", min_samples_leaf=7, learning_rate=0.01, max_depth=5, n_estimators=300  |
+|                0.9578 | max_features="log2", min_samples_leaf=1, learning_rate=0.01, max_depth=7, n_estimators=300  |
+|                0.9577 | max_features="log2", min_samples_leaf=3, learning_rate=0.01, max_depth=7, n_estimators=300  |
+|                0.9577 | max_features="log2", min_samples_leaf=3, learning_rate=0.1, max_depth=7, n_estimators=100   |
+|                0.9577 | max_features="log2", min_samples_leaf=5, learning_rate=0.5, max_depth=1, n_estimators=500   |
+|                0.9575 | max_features="log2", min_samples_leaf=7, learning_rate=0.5, max_depth=1, n_estimators=700   |
+|                0.9573 | max_features="log2", min_samples_leaf=13, learning_rate=0.5, max_depth=1, n_estimators=500  |
+|                0.9571 | max_features="log2", min_samples_leaf=5, learning_rate=0.5, max_depth=1, n_estimators=100   |
+|                0.957  | max_features="log2", min_samples_leaf=5, learning_rate=0.01, max_depth=7, n_estimators=100  |
+|                0.957  | max_features="log2", min_samples_leaf=1, learning_rate=0.1, max_depth=3, n_estimators=500   |
+|                0.9569 | max_features="log2", min_samples_leaf=3, learning_rate=0.01, max_depth=7, n_estimators=100  |
+|                0.9568 | max_features="log2", min_samples_leaf=5, learning_rate=0.5, max_depth=1, n_estimators=700   |
+|                0.9566 | max_features="log2", min_samples_leaf=7, learning_rate=0.1, max_depth=7, n_estimators=100   |
+|                0.9564 | max_features="log2", min_samples_leaf=13, learning_rate=0.5, max_depth=1, n_estimators=700  |
+|                0.9563 | max_features="log2", min_samples_leaf=5, learning_rate=0.1, max_depth=5, n_estimators=300   |
+|                0.9561 | max_features="log2", min_samples_leaf=13, learning_rate=0.1, max_depth=5, n_estimators=300  |
+|                0.9557 | max_features="log2", min_samples_leaf=3, learning_rate=0.1, max_depth=3, n_estimators=700   |
+|                0.9556 | max_features="log2", min_samples_leaf=7, learning_rate=0.5, max_depth=1, n_estimators=100   |
+|                0.9553 | max_features="log2", min_samples_leaf=13, learning_rate=0.01, max_depth=3, n_estimators=300 |
+|                0.9553 | max_features="log2", min_samples_leaf=7, learning_rate=0.01, max_depth=3, n_estimators=300  |
+|                0.9551 | max_features="log2", min_samples_leaf=3, learning_rate=0.1, max_depth=5, n_estimators=300   |
+|                0.955  | max_features="log2", min_samples_leaf=5, learning_rate=0.01, max_depth=3, n_estimators=300  |
+|                0.955  | max_features="log2", min_samples_leaf=1, learning_rate=0.01, max_depth=3, n_estimators=300  |
+|                0.955  | max_features="log2", min_samples_leaf=7, learning_rate=0.01, max_depth=7, n_estimators=100  |
+|                0.9548 | max_features="log2", min_samples_leaf=13, learning_rate=0.1, max_depth=7, n_estimators=100  |
+|                0.9545 | max_features="log2", min_samples_leaf=13, learning_rate=0.01, max_depth=7, n_estimators=100 |
+|                0.9544 | max_features="log2", min_samples_leaf=1, learning_rate=0.01, max_depth=5, n_estimators=100  |
+|                0.9543 | max_features="log2", min_samples_leaf=7, learning_rate=0.1, max_depth=5, n_estimators=300   |
+|                0.9543 | max_features="log2", min_samples_leaf=1, learning_rate=0.1, max_depth=7, n_estimators=100   |
+|                0.9543 | max_features="log2", min_samples_leaf=5, learning_rate=0.01, max_depth=5, n_estimators=100  |
+|                0.9542 | max_features="log2", min_samples_leaf=13, learning_rate=0.1, max_depth=3, n_estimators=700  |
+|                0.954  | max_features="log2", min_samples_leaf=1, learning_rate=0.01, max_depth=7, n_estimators=100  |
+|                0.9538 | max_features="log2", min_samples_leaf=3, learning_rate=0.01, max_depth=3, n_estimators=300  |
+|                0.9535 | max_features="log2", min_samples_leaf=3, learning_rate=0.1, max_depth=1, n_estimators=100   |
+|                0.9533 | max_features="log2", min_samples_leaf=5, learning_rate=0.1, max_depth=3, n_estimators=700   |
+|                0.953  | max_features="log2", min_samples_leaf=13, learning_rate=0.01, max_depth=5, n_estimators=100 |
+|                0.9529 | max_features="log2", min_samples_leaf=13, learning_rate=0.1, max_depth=1, n_estimators=100  |
+|                0.9528 | max_features="log2", min_samples_leaf=7, learning_rate=0.1, max_depth=3, n_estimators=700   |
+|                0.9528 | max_features="log2", min_samples_leaf=1, learning_rate=0.1, max_depth=3, n_estimators=700   |
+|                0.9527 | max_features="log2", min_samples_leaf=3, learning_rate=0.01, max_depth=5, n_estimators=100  |
+|                0.9526 | max_features="log2", min_samples_leaf=7, learning_rate=0.01, max_depth=5, n_estimators=100  |
+|                0.951  | max_features="log2", min_samples_leaf=1, learning_rate=0.01, max_depth=1, n_estimators=700  |
+|                0.9504 | max_features="log2", min_samples_leaf=13, learning_rate=0.01, max_depth=3, n_estimators=100 |
+|                0.9498 | max_features="log2", min_samples_leaf=7, learning_rate=0.01, max_depth=1, n_estimators=700  |
+|                0.9497 | max_features="log2", min_samples_leaf=13, learning_rate=0.01, max_depth=1, n_estimators=700 |
+|                0.9496 | max_features="log2", min_samples_leaf=5, learning_rate=0.01, max_depth=1, n_estimators=700  |
+|                0.9496 | max_features="log2", min_samples_leaf=5, learning_rate=0.1, max_depth=1, n_estimators=100   |
+|                0.9495 | max_features="log2", min_samples_leaf=3, learning_rate=0.01, max_depth=1, n_estimators=700  |
+|                0.949  | max_features="log2", min_samples_leaf=1, learning_rate=0.1, max_depth=5, n_estimators=300   |
+|                0.9483 | max_features="log2", min_samples_leaf=7, learning_rate=0.01, max_depth=3, n_estimators=100  |
+|                0.9481 | max_features="log2", min_samples_leaf=7, learning_rate=0.1, max_depth=1, n_estimators=100   |
+|                0.9481 | max_features="log2", min_samples_leaf=1, learning_rate=0.1, max_depth=1, n_estimators=100   |
+|                0.9478 | max_features="log2", min_samples_leaf=7, learning_rate=0.01, max_depth=1, n_estimators=500  |
+|                0.9472 | max_features="log2", min_samples_leaf=13, learning_rate=0.01, max_depth=1, n_estimators=500 |
+|                0.9472 | max_features="log2", min_samples_leaf=3, learning_rate=0.01, max_depth=3, n_estimators=100  |
+|                0.9471 | max_features="log2", min_samples_leaf=5, learning_rate=0.01, max_depth=1, n_estimators=500  |
+|                0.9468 | max_features="log2", min_samples_leaf=3, learning_rate=0.01, max_depth=1, n_estimators=500  |
+|                0.9467 | max_features="log2", min_samples_leaf=1, learning_rate=0.01, max_depth=1, n_estimators=500  |
+|                0.9465 | max_features="log2", min_samples_leaf=5, learning_rate=0.01, max_depth=3, n_estimators=100  |
+|                0.9464 | max_features="log2", min_samples_leaf=1, learning_rate=0.01, max_depth=3, n_estimators=100  |
+|                0.9458 | max_features="log2", min_samples_leaf=3, learning_rate=1, max_depth=1, n_estimators=100     |
+|                0.9457 | max_features="log2", min_samples_leaf=7, learning_rate=0.01, max_depth=1, n_estimators=300  |
+|                0.9456 | max_features="log2", min_samples_leaf=3, learning_rate=0.01, max_depth=1, n_estimators=300  |
+|                0.945  | max_features="log2", min_samples_leaf=1, learning_rate=0.5, max_depth=3, n_estimators=100   |
+|                0.9445 | max_features="log2", min_samples_leaf=13, learning_rate=0.01, max_depth=1, n_estimators=300 |
+|                0.9444 | max_features="log2", min_samples_leaf=1, learning_rate=0.01, max_depth=1, n_estimators=300  |
+|                0.9439 | max_features="log2", min_samples_leaf=5, learning_rate=0.01, max_depth=1, n_estimators=300  |
+|                0.9419 | max_features="log2", min_samples_leaf=1, learning_rate=1, max_depth=1, n_estimators=100     |
+|                0.9411 | max_features="log2", min_samples_leaf=3, learning_rate=0.5, max_depth=3, n_estimators=100   |
+|                0.9408 | max_features="log2", min_samples_leaf=13, learning_rate=0.1, max_depth=5, n_estimators=500  |
+|                0.9405 | max_features="log2", min_samples_leaf=1, learning_rate=0.01, max_depth=1, n_estimators=100  |
+|                0.9405 | max_features="log2", min_samples_leaf=5, learning_rate=0.01, max_depth=1, n_estimators=100  |
+|                0.9405 | max_features="log2", min_samples_leaf=7, learning_rate=0.01, max_depth=1, n_estimators=100  |
+|                0.9405 | max_features="log2", min_samples_leaf=13, learning_rate=0.5, max_depth=3, n_estimators=100  |
+|                0.9395 | max_features="log2", min_samples_leaf=5, learning_rate=0.1, max_depth=5, n_estimators=500   |
+|                0.9384 | max_features="log2", min_samples_leaf=3, learning_rate=0.01, max_depth=1, n_estimators=100  |
+|                0.9383 | max_features="log2", min_samples_leaf=7, learning_rate=0.5, max_depth=3, n_estimators=100   |
+|                0.9374 | max_features="log2", min_samples_leaf=3, learning_rate=0.1, max_depth=5, n_estimators=500   |
+|                0.9372 | max_features="log2", min_samples_leaf=5, learning_rate=0.5, max_depth=3, n_estimators=100   |
+|                0.9371 | max_features="log2", min_samples_leaf=1, learning_rate=0.1, max_depth=5, n_estimators=500   |
+|                0.9367 | max_features="log2", min_samples_leaf=13, learning_rate=0.01, max_depth=1, n_estimators=100 |
+|                0.9322 | max_features="log2", min_samples_leaf=7, learning_rate=0.1, max_depth=5, n_estimators=500   |
+|                0.932  | max_features="log2", min_samples_leaf=7, learning_rate=1, max_depth=1, n_estimators=700     |
+|                0.9314 | max_features="log2", min_samples_leaf=7, learning_rate=1, max_depth=1, n_estimators=500     |
+|                0.9295 | max_features="log2", min_samples_leaf=3, learning_rate=1, max_depth=1, n_estimators=300     |
+|                0.9275 | max_features="log2", min_samples_leaf=13, learning_rate=0.5, max_depth=3, n_estimators=300  |
+|                0.9259 | max_features="log2", min_samples_leaf=1, learning_rate=0.5, max_depth=3, n_estimators=300   |
+|                0.9224 | max_features="log2", min_samples_leaf=13, learning_rate=0.1, max_depth=7, n_estimators=300  |
+|                0.9217 | max_features="log2", min_samples_leaf=5, learning_rate=0.5, max_depth=3, n_estimators=300   |
+|                0.9207 | max_features="log2", min_samples_leaf=13, learning_rate=0.1, max_depth=5, n_estimators=700  |
+|                0.9207 | max_features="log2", min_samples_leaf=7, learning_rate=0.5, max_depth=3, n_estimators=300   |
+|                0.9199 | max_features="log2", min_samples_leaf=7, learning_rate=0.1, max_depth=7, n_estimators=300   |
+|                0.9155 | max_features="log2", min_samples_leaf=1, learning_rate=0.1, max_depth=5, n_estimators=700   |
+|                0.9148 | max_features="log2", min_samples_leaf=5, learning_rate=0.1, max_depth=5, n_estimators=700   |
+|                0.914  | max_features="log2", min_samples_leaf=13, learning_rate=0.5, max_depth=5, n_estimators=100  |
+|                0.9136 | max_features="log2", min_samples_leaf=7, learning_rate=0.5, max_depth=5, n_estimators=100   |
+|                0.9128 | max_features="log2", min_samples_leaf=3, learning_rate=0.1, max_depth=5, n_estimators=700   |
+|                0.9124 | max_features="log2", min_samples_leaf=1, learning_rate=0.5, max_depth=5, n_estimators=100   |
+|                0.9114 | max_features="log2", min_samples_leaf=5, learning_rate=0.1, max_depth=7, n_estimators=300   |
+|                0.9111 | max_features="log2", min_samples_leaf=7, learning_rate=0.1, max_depth=5, n_estimators=700   |
+|                0.9093 | max_features="log2", min_samples_leaf=3, learning_rate=0.1, max_depth=7, n_estimators=300   |
+|                0.9091 | max_features="log2", min_samples_leaf=1, learning_rate=0.1, max_depth=7, n_estimators=300   |
+|                0.9078 | max_features="log2", min_samples_leaf=1, learning_rate=1, max_depth=1, n_estimators=300     |
+|                0.9071 | max_features="log2", min_samples_leaf=5, learning_rate=0.5, max_depth=5, n_estimators=100   |
+|                0.9049 | max_features="log2", min_samples_leaf=3, learning_rate=0.5, max_depth=5, n_estimators=100   |
+|                0.9025 | max_features="log2", min_samples_leaf=3, learning_rate=0.5, max_depth=3, n_estimators=300   |
+|                0.9019 | max_features="log2", min_samples_leaf=3, learning_rate=0.5, max_depth=3, n_estimators=500   |
+|                0.892  | max_features="log2", min_samples_leaf=7, learning_rate=1, max_depth=3, n_estimators=100     |
+|                0.8911 | max_features="log2", min_samples_leaf=7, learning_rate=0.5, max_depth=3, n_estimators=500   |
+|                0.8909 | max_features="log2", min_samples_leaf=1, learning_rate=0.5, max_depth=3, n_estimators=500   |
+|                0.8894 | max_features="log2", min_samples_leaf=5, learning_rate=0.5, max_depth=3, n_estimators=500   |
+|                0.8867 | max_features="log2", min_samples_leaf=5, learning_rate=1, max_depth=3, n_estimators=100     |
+|                0.8841 | max_features="log2", min_samples_leaf=13, learning_rate=0.1, max_depth=7, n_estimators=500  |
+|                0.8814 | max_features="log2", min_samples_leaf=13, learning_rate=0.5, max_depth=3, n_estimators=500  |
+|                0.8783 | max_features="log2", min_samples_leaf=7, learning_rate=0.1, max_depth=7, n_estimators=500   |
+|                0.8731 | max_features="log2", min_samples_leaf=7, learning_rate=0.1, max_depth=7, n_estimators=700   |
+|                0.8721 | max_features="log2", min_samples_leaf=13, learning_rate=0.1, max_depth=7, n_estimators=700  |
+|                0.8716 | max_features="log2", min_samples_leaf=1, learning_rate=0.1, max_depth=7, n_estimators=700   |
+|                0.8715 | max_features="log2", min_samples_leaf=7, learning_rate=0.5, max_depth=3, n_estimators=700   |
+|                0.8695 | max_features="log2", min_samples_leaf=5, learning_rate=0.5, max_depth=3, n_estimators=700   |
+|                0.8692 | max_features="log2", min_samples_leaf=1, learning_rate=0.1, max_depth=7, n_estimators=500   |
+|                0.8677 | max_features="log2", min_samples_leaf=3, learning_rate=0.1, max_depth=7, n_estimators=500   |
+|                0.8674 | max_features="log2", min_samples_leaf=5, learning_rate=0.1, max_depth=7, n_estimators=700   |
+|                0.8672 | max_features="log2", min_samples_leaf=5, learning_rate=0.1, max_depth=7, n_estimators=500   |
+|                0.8666 | max_features="log2", min_samples_leaf=3, learning_rate=1, max_depth=3, n_estimators=100     |
+|                0.8661 | max_features="log2", min_samples_leaf=3, learning_rate=0.5, max_depth=3, n_estimators=700   |
+|                0.8654 | max_features="log2", min_samples_leaf=13, learning_rate=0.5, max_depth=3, n_estimators=700  |
+|                0.8596 | max_features="log2", min_samples_leaf=3, learning_rate=0.1, max_depth=7, n_estimators=700   |
+|                0.8516 | max_features="log2", min_samples_leaf=13, learning_rate=0.5, max_depth=7, n_estimators=100  |
+|                0.8486 | max_features="log2", min_samples_leaf=3, learning_rate=1, max_depth=3, n_estimators=300     |
+|                0.8463 | max_features="log2", min_samples_leaf=7, learning_rate=1, max_depth=3, n_estimators=300     |
+|                0.8457 | max_features="log2", min_samples_leaf=3, learning_rate=0.5, max_depth=7, n_estimators=300   |
+|                0.8451 | max_features="log2", min_samples_leaf=1, learning_rate=0.5, max_depth=5, n_estimators=700   |
+|                0.8451 | max_features="log2", min_samples_leaf=3, learning_rate=0.5, max_depth=5, n_estimators=700   |
+|                0.844  | max_features="log2", min_samples_leaf=1, learning_rate=0.5, max_depth=3, n_estimators=700   |
+|                0.844  | max_features="log2", min_samples_leaf=3, learning_rate=0.5, max_depth=7, n_estimators=700   |
+|                0.8437 | max_features="log2", min_samples_leaf=3, learning_rate=0.5, max_depth=5, n_estimators=300   |
+|                0.8435 | max_features="log2", min_samples_leaf=13, learning_rate=0.5, max_depth=5, n_estimators=700  |
+|                0.8426 | max_features="log2", min_samples_leaf=13, learning_rate=0.5, max_depth=7, n_estimators=700  |
+|                0.8425 | max_features="log2", min_samples_leaf=7, learning_rate=0.5, max_depth=7, n_estimators=700   |
+|                0.8417 | max_features="log2", min_samples_leaf=7, learning_rate=0.5, max_depth=7, n_estimators=300   |
+|                0.8414 | max_features="log2", min_samples_leaf=7, learning_rate=0.5, max_depth=5, n_estimators=300   |
+|                0.841  | max_features="log2", min_samples_leaf=13, learning_rate=0.5, max_depth=5, n_estimators=500  |
+|                0.8396 | max_features="log2", min_samples_leaf=5, learning_rate=1, max_depth=1, n_estimators=100     |
+|                0.8395 | max_features="log2", min_samples_leaf=7, learning_rate=0.5, max_depth=7, n_estimators=500   |
+|                0.8389 | max_features="log2", min_samples_leaf=1, learning_rate=0.5, max_depth=5, n_estimators=300   |
+|                0.8378 | max_features="log2", min_samples_leaf=5, learning_rate=0.5, max_depth=7, n_estimators=100   |
+|                0.8377 | max_features="log2", min_samples_leaf=13, learning_rate=0.5, max_depth=5, n_estimators=300  |
+|                0.837  | max_features="log2", min_samples_leaf=5, learning_rate=0.5, max_depth=5, n_estimators=700   |
+|                0.8362 | max_features="log2", min_samples_leaf=13, learning_rate=0.5, max_depth=7, n_estimators=300  |
+|                0.8362 | max_features="log2", min_samples_leaf=3, learning_rate=0.5, max_depth=7, n_estimators=100   |
+|                0.8358 | max_features="log2", min_samples_leaf=1, learning_rate=0.5, max_depth=7, n_estimators=700   |
+|                0.835  | max_features="log2", min_samples_leaf=13, learning_rate=1, max_depth=3, n_estimators=100    |
+|                0.8344 | max_features="log2", min_samples_leaf=5, learning_rate=0.5, max_depth=5, n_estimators=300   |
+|                0.8326 | max_features="log2", min_samples_leaf=5, learning_rate=0.5, max_depth=7, n_estimators=700   |
+|                0.8296 | max_features="log2", min_samples_leaf=5, learning_rate=0.5, max_depth=7, n_estimators=300   |
+|                0.8276 | max_features="log2", min_samples_leaf=7, learning_rate=0.5, max_depth=7, n_estimators=100   |
+|                0.8257 | max_features="log2", min_samples_leaf=5, learning_rate=0.5, max_depth=5, n_estimators=500   |
+|                0.8235 | max_features="log2", min_samples_leaf=13, learning_rate=1, max_depth=1, n_estimators=300    |
+|                0.8229 | max_features="log2", min_samples_leaf=1, learning_rate=0.5, max_depth=7, n_estimators=300   |
+|                0.8227 | max_features="log2", min_samples_leaf=13, learning_rate=1, max_depth=1, n_estimators=500    |
+|                0.8208 | max_features="log2", min_samples_leaf=1, learning_rate=0.5, max_depth=7, n_estimators=100   |
+|                0.82   | max_features="log2", min_samples_leaf=1, learning_rate=0.5, max_depth=7, n_estimators=500   |
+|                0.8182 | max_features="log2", min_samples_leaf=1, learning_rate=1, max_depth=1, n_estimators=700     |
+|                0.8098 | max_features="log2", min_samples_leaf=7, learning_rate=1, max_depth=1, n_estimators=300     |
+|                0.8088 | max_features="log2", min_samples_leaf=13, learning_rate=1, max_depth=3, n_estimators=300    |
+|                0.8059 | max_features="log2", min_samples_leaf=3, learning_rate=0.5, max_depth=5, n_estimators=500   |
+|                0.8042 | max_features="log2", min_samples_leaf=13, learning_rate=0.5, max_depth=7, n_estimators=500  |
+|                0.8033 | max_features="log2", min_samples_leaf=3, learning_rate=1, max_depth=1, n_estimators=700     |
+|                0.8025 | max_features="log2", min_samples_leaf=3, learning_rate=0.5, max_depth=7, n_estimators=500   |
+|                0.8019 | max_features="log2", min_samples_leaf=3, learning_rate=1, max_depth=3, n_estimators=700     |
+|                0.8017 | max_features="log2", min_samples_leaf=7, learning_rate=0.5, max_depth=5, n_estimators=700   |
+|                0.798  | max_features="log2", min_samples_leaf=1, learning_rate=1, max_depth=3, n_estimators=100     |
+|                0.795  | max_features="log2", min_samples_leaf=1, learning_rate=0.5, max_depth=5, n_estimators=500   |
+|                0.7946 | max_features="log2", min_samples_leaf=13, learning_rate=1, max_depth=1, n_estimators=100    |
+|                0.7865 | max_features="log2", min_samples_leaf=5, learning_rate=1, max_depth=1, n_estimators=500     |
+|                0.7822 | max_features="log2", min_samples_leaf=7, learning_rate=0.5, max_depth=5, n_estimators=500   |
+|                0.7795 | max_features="log2", min_samples_leaf=1, learning_rate=1, max_depth=1, n_estimators=500     |
+|                0.775  | max_features="log2", min_samples_leaf=5, learning_rate=1, max_depth=5, n_estimators=100     |
+|                0.7743 | max_features="log2", min_samples_leaf=5, learning_rate=1, max_depth=3, n_estimators=700     |
+|                0.7712 | max_features="log2", min_samples_leaf=7, learning_rate=1, max_depth=1, n_estimators=100     |
+|                0.7695 | max_features="log2", min_samples_leaf=1, learning_rate=1, max_depth=5, n_estimators=100     |
+|                0.7682 | max_features="log2", min_samples_leaf=7, learning_rate=1, max_depth=5, n_estimators=100     |
+|                0.7654 | max_features="log2", min_samples_leaf=5, learning_rate=0.5, max_depth=7, n_estimators=500   |
+|                0.7608 | max_features="log2", min_samples_leaf=3, learning_rate=1, max_depth=3, n_estimators=500     |
+|                0.7537 | max_features="log2", min_samples_leaf=13, learning_rate=1, max_depth=1, n_estimators=700    |
+|                0.7524 | max_features="log2", min_samples_leaf=3, learning_rate=1, max_depth=5, n_estimators=100     |
+|                0.7511 | max_features="log2", min_samples_leaf=1, learning_rate=1, max_depth=3, n_estimators=500     |
+|                0.7499 | max_features="log2", min_samples_leaf=1, learning_rate=1, max_depth=3, n_estimators=300     |
+|                0.7491 | max_features="log2", min_samples_leaf=7, learning_rate=1, max_depth=3, n_estimators=500     |
+|                0.7455 | max_features="log2", min_samples_leaf=1, learning_rate=1, max_depth=7, n_estimators=100     |
+|                0.7454 | max_features="log2", min_samples_leaf=5, learning_rate=1, max_depth=5, n_estimators=300     |
+|                0.7382 | max_features="log2", min_samples_leaf=13, learning_rate=1, max_depth=7, n_estimators=100    |
+|                0.7352 | max_features="log2", min_samples_leaf=3, learning_rate=1, max_depth=7, n_estimators=100     |
+|                0.7339 | max_features="log2", min_samples_leaf=5, learning_rate=1, max_depth=7, n_estimators=500     |
+|                0.7315 | max_features="log2", min_samples_leaf=13, learning_rate=1, max_depth=5, n_estimators=100    |
+|                0.7292 | max_features="log2", min_samples_leaf=5, learning_rate=1, max_depth=5, n_estimators=500     |
+|                0.7284 | max_features="log2", min_samples_leaf=1, learning_rate=1, max_depth=7, n_estimators=700     |
+|                0.727  | max_features="log2", min_samples_leaf=7, learning_rate=1, max_depth=7, n_estimators=300     |
+|                0.7265 | max_features="log2", min_samples_leaf=7, learning_rate=1, max_depth=7, n_estimators=500     |
+|                0.7213 | max_features="log2", min_samples_leaf=13, learning_rate=1, max_depth=7, n_estimators=500    |
+|                0.7182 | max_features="log2", min_samples_leaf=3, learning_rate=1, max_depth=7, n_estimators=300     |
+|                0.7093 | max_features="log2", min_samples_leaf=3, learning_rate=1, max_depth=1, n_estimators=500     |
+|                0.7089 | max_features="log2", min_samples_leaf=13, learning_rate=1, max_depth=5, n_estimators=500    |
+|                0.7088 | max_features="log2", min_samples_leaf=13, learning_rate=1, max_depth=5, n_estimators=300    |
+|                0.7062 | max_features="log2", min_samples_leaf=5, learning_rate=1, max_depth=5, n_estimators=700     |
+|                0.7054 | max_features="log2", min_samples_leaf=5, learning_rate=1, max_depth=3, n_estimators=300     |
+|                0.7007 | max_features="log2", min_samples_leaf=7, learning_rate=1, max_depth=7, n_estimators=100     |
+|                0.7005 | max_features="log2", min_samples_leaf=7, learning_rate=1, max_depth=5, n_estimators=500     |
+|                0.6982 | max_features="log2", min_samples_leaf=3, learning_rate=1, max_depth=5, n_estimators=700     |
+|                0.6978 | max_features="log2", min_samples_leaf=1, learning_rate=1, max_depth=7, n_estimators=300     |
+|                0.6925 | max_features="log2", min_samples_leaf=5, learning_rate=1, max_depth=1, n_estimators=700     |
+|                0.6915 | max_features="log2", min_samples_leaf=3, learning_rate=1, max_depth=5, n_estimators=300     |
+|                0.6831 | max_features="log2", min_samples_leaf=13, learning_rate=1, max_depth=5, n_estimators=700    |
+|                0.6813 | max_features="log2", min_samples_leaf=13, learning_rate=1, max_depth=7, n_estimators=300    |
+|                0.6785 | max_features="log2", min_samples_leaf=3, learning_rate=1, max_depth=7, n_estimators=500     |
+|                0.6755 | max_features="log2", min_samples_leaf=1, learning_rate=1, max_depth=3, n_estimators=700     |
+|                0.6754 | max_features="log2", min_samples_leaf=7, learning_rate=1, max_depth=7, n_estimators=700     |
+|                0.6658 | max_features="log2", min_samples_leaf=7, learning_rate=1, max_depth=5, n_estimators=300     |
+|                0.6649 | max_features="log2", min_samples_leaf=5, learning_rate=1, max_depth=7, n_estimators=100     |
+|                0.6617 | max_features="log2", min_samples_leaf=13, learning_rate=1, max_depth=3, n_estimators=500    |
+|                0.6565 | max_features="log2", min_samples_leaf=5, learning_rate=1, max_depth=7, n_estimators=700     |
+|                0.6506 | max_features="log2", min_samples_leaf=1, learning_rate=1, max_depth=5, n_estimators=300     |
+|                0.6458 | max_features="log2", min_samples_leaf=13, learning_rate=1, max_depth=7, n_estimators=700    |
+|                0.6429 | max_features="log2", min_samples_leaf=3, learning_rate=1, max_depth=7, n_estimators=700     |
+|                0.6412 | max_features="log2", min_samples_leaf=5, learning_rate=1, max_depth=7, n_estimators=300     |
+|                0.6342 | max_features="log2", min_samples_leaf=7, learning_rate=1, max_depth=5, n_estimators=700     |
+|                0.6334 | max_features="log2", min_samples_leaf=7, learning_rate=1, max_depth=3, n_estimators=700     |
+|                0.6285 | max_features="log2", min_samples_leaf=5, learning_rate=1, max_depth=1, n_estimators=300     |
+|                0.6273 | max_features="log2", min_samples_leaf=1, learning_rate=1, max_depth=5, n_estimators=700     |
+|                0.626  | max_features="log2", min_samples_leaf=1, learning_rate=1, max_depth=7, n_estimators=500     |
+|                0.6254 | max_features="log2", min_samples_leaf=13, learning_rate=1, max_depth=3, n_estimators=700    |
+|                0.6213 | max_features="log2", min_samples_leaf=1, learning_rate=1, max_depth=5, n_estimators=500     |
+|                0.6185 | max_features="log2", min_samples_leaf=5, learning_rate=1, max_depth=3, n_estimators=500     |
+|                0.6157 | max_features="log2", min_samples_leaf=3, learning_rate=1, max_depth=5, n_estimators=500     |
 

--- a/tuning_reports/huwiki.goodfaith.md
+++ b/tuning_reports/huwiki.goodfaith.md
@@ -1,185 +1,442 @@
 # Model tuning report
-- Revscoring version: 2.1.0
+- Revscoring version: 2.4.0
 - Features: editquality.feature_lists.huwiki.goodfaith
-- Date: 2018-04-10T12:29:54.706444
-- Observations: 39674
+- Date: 2019-07-23T01:16:08.269597
+- Observations: 37729
 - Labels: [true, false]
-- Statistic: roc_auc.labels.true (maximize)
+- Statistic: roc_auc.labels.false (maximize)
 - Folds: 5
 
 # Top scoring configurations
-| model                  |   roc_auc.labels.true | params                                                                        |
-|:-----------------------|----------------------:|:------------------------------------------------------------------------------|
-| GradientBoosting       |                0.984  | max_depth=7, max_features="log2", learning_rate=0.1, n_estimators=700         |
-| GradientBoosting       |                0.9831 | max_depth=7, max_features="log2", learning_rate=0.5, n_estimators=500         |
-| GradientBoosting       |                0.9828 | max_depth=7, max_features="log2", learning_rate=0.5, n_estimators=300         |
-| GradientBoosting       |                0.9817 | max_depth=7, max_features="log2", learning_rate=0.1, n_estimators=500         |
-| GradientBoosting       |                0.9724 | max_depth=5, max_features="log2", learning_rate=0.5, n_estimators=300         |
-| GradientBoosting       |                0.971  | max_depth=7, max_features="log2", learning_rate=0.5, n_estimators=100         |
-| GradientBoosting       |                0.9703 | max_depth=5, max_features="log2", learning_rate=0.5, n_estimators=700         |
-| RandomForestClassifier |                0.9697 | max_features="log2", min_samples_leaf=1, n_estimators=10, criterion="gini"    |
-| RandomForestClassifier |                0.969  | max_features="log2", min_samples_leaf=1, n_estimators=10, criterion="entropy" |
-| GradientBoosting       |                0.9665 | max_depth=7, max_features="log2", learning_rate=0.1, n_estimators=300         |
+| model                  |   roc_auc.labels.false | params                                                                                     |
+|:-----------------------|-----------------------:|:-------------------------------------------------------------------------------------------|
+| RandomForestClassifier |                 0.9641 | criterion="entropy", max_features="log2", min_samples_leaf=7, n_estimators=640             |
+| GradientBoosting       |                 0.9637 | max_features="log2", max_depth=1, min_samples_leaf=1, learning_rate=0.1, n_estimators=700  |
+| GradientBoosting       |                 0.9635 | max_features="log2", max_depth=1, min_samples_leaf=5, learning_rate=0.1, n_estimators=700  |
+| GradientBoosting       |                 0.9633 | max_features="log2", max_depth=1, min_samples_leaf=1, learning_rate=0.1, n_estimators=500  |
+| RandomForestClassifier |                 0.9633 | criterion="entropy", max_features="log2", min_samples_leaf=5, n_estimators=640             |
+| GradientBoosting       |                 0.9629 | max_features="log2", max_depth=1, min_samples_leaf=13, learning_rate=0.1, n_estimators=500 |
+| GradientBoosting       |                 0.9629 | max_features="log2", max_depth=1, min_samples_leaf=5, learning_rate=0.1, n_estimators=500  |
+| GradientBoosting       |                 0.9628 | max_features="log2", max_depth=1, min_samples_leaf=3, learning_rate=0.1, n_estimators=700  |
+| GradientBoosting       |                 0.9626 | max_features="log2", max_depth=1, min_samples_leaf=7, learning_rate=0.1, n_estimators=700  |
+| GradientBoosting       |                 0.9626 | max_features="log2", max_depth=3, min_samples_leaf=13, learning_rate=0.1, n_estimators=100 |
 
 # Models
-## RandomForestClassifier
-|   roc_auc.labels.true | params                                                                          |
-|----------------------:|:--------------------------------------------------------------------------------|
-|                0.9697 | max_features="log2", min_samples_leaf=1, n_estimators=10, criterion="gini"      |
-|                0.969  | max_features="log2", min_samples_leaf=1, n_estimators=10, criterion="entropy"   |
-|                0.9627 | max_features="log2", min_samples_leaf=1, n_estimators=20, criterion="gini"      |
-|                0.9606 | max_features="log2", min_samples_leaf=1, n_estimators=20, criterion="entropy"   |
-|                0.9556 | max_features="log2", min_samples_leaf=1, n_estimators=40, criterion="entropy"   |
-|                0.9545 | max_features="log2", min_samples_leaf=1, n_estimators=40, criterion="gini"      |
-|                0.9523 | max_features="log2", min_samples_leaf=3, n_estimators=10, criterion="entropy"   |
-|                0.9495 | max_features="log2", min_samples_leaf=3, n_estimators=10, criterion="gini"      |
-|                0.9479 | max_features="log2", min_samples_leaf=5, n_estimators=10, criterion="gini"      |
-|                0.9468 | max_features="log2", min_samples_leaf=1, n_estimators=80, criterion="entropy"   |
-|                0.9454 | max_features="log2", min_samples_leaf=5, n_estimators=10, criterion="entropy"   |
-|                0.945  | max_features="log2", min_samples_leaf=1, n_estimators=80, criterion="gini"      |
-|                0.9418 | max_features="log2", min_samples_leaf=7, n_estimators=10, criterion="entropy"   |
-|                0.9399 | max_features="log2", min_samples_leaf=3, n_estimators=20, criterion="entropy"   |
-|                0.9387 | max_features="log2", min_samples_leaf=7, n_estimators=10, criterion="gini"      |
-|                0.9372 | max_features="log2", min_samples_leaf=3, n_estimators=20, criterion="gini"      |
-|                0.9369 | max_features="log2", min_samples_leaf=13, n_estimators=10, criterion="entropy"  |
-|                0.9356 | max_features="log2", min_samples_leaf=3, n_estimators=40, criterion="entropy"   |
-|                0.9343 | max_features="log2", min_samples_leaf=1, n_estimators=160, criterion="entropy"  |
-|                0.9343 | max_features="log2", min_samples_leaf=5, n_estimators=20, criterion="entropy"   |
-|                0.9335 | max_features="log2", min_samples_leaf=3, n_estimators=40, criterion="gini"      |
-|                0.9326 | max_features="log2", min_samples_leaf=1, n_estimators=160, criterion="gini"     |
-|                0.9319 | max_features="log2", min_samples_leaf=7, n_estimators=40, criterion="entropy"   |
-|                0.9316 | max_features="log2", min_samples_leaf=5, n_estimators=20, criterion="gini"      |
-|                0.9315 | max_features="log2", min_samples_leaf=7, n_estimators=20, criterion="gini"      |
-|                0.9309 | max_features="log2", min_samples_leaf=7, n_estimators=20, criterion="entropy"   |
-|                0.9299 | max_features="log2", min_samples_leaf=5, n_estimators=40, criterion="entropy"   |
-|                0.9298 | max_features="log2", min_samples_leaf=13, n_estimators=10, criterion="gini"     |
-|                0.9293 | max_features="log2", min_samples_leaf=5, n_estimators=40, criterion="gini"      |
-|                0.9292 | max_features="log2", min_samples_leaf=1, n_estimators=320, criterion="entropy"  |
-|                0.9279 | max_features="log2", min_samples_leaf=13, n_estimators=80, criterion="entropy"  |
-|                0.9274 | max_features="log2", min_samples_leaf=1, n_estimators=640, criterion="entropy"  |
-|                0.9268 | max_features="log2", min_samples_leaf=13, n_estimators=40, criterion="entropy"  |
-|                0.9256 | max_features="log2", min_samples_leaf=3, n_estimators=80, criterion="entropy"   |
-|                0.9254 | max_features="log2", min_samples_leaf=13, n_estimators=640, criterion="entropy" |
-|                0.9253 | max_features="log2", min_samples_leaf=1, n_estimators=320, criterion="gini"     |
-|                0.9243 | max_features="log2", min_samples_leaf=1, n_estimators=640, criterion="gini"     |
-|                0.9242 | max_features="log2", min_samples_leaf=7, n_estimators=320, criterion="entropy"  |
-|                0.924  | max_features="log2", min_samples_leaf=3, n_estimators=320, criterion="entropy"  |
-|                0.9239 | max_features="log2", min_samples_leaf=13, n_estimators=320, criterion="gini"    |
-|                0.9234 | max_features="log2", min_samples_leaf=7, n_estimators=40, criterion="gini"      |
-|                0.923  | max_features="log2", min_samples_leaf=5, n_estimators=160, criterion="entropy"  |
-|                0.9229 | max_features="log2", min_samples_leaf=7, n_estimators=160, criterion="entropy"  |
-|                0.9227 | max_features="log2", min_samples_leaf=5, n_estimators=80, criterion="entropy"   |
-|                0.9226 | max_features="log2", min_samples_leaf=7, n_estimators=640, criterion="gini"     |
-|                0.9225 | max_features="log2", min_samples_leaf=7, n_estimators=640, criterion="entropy"  |
-|                0.922  | max_features="log2", min_samples_leaf=13, n_estimators=640, criterion="gini"    |
-|                0.9219 | max_features="log2", min_samples_leaf=13, n_estimators=160, criterion="gini"    |
-|                0.9219 | max_features="log2", min_samples_leaf=5, n_estimators=320, criterion="entropy"  |
-|                0.9216 | max_features="log2", min_samples_leaf=3, n_estimators=80, criterion="gini"      |
-|                0.9216 | max_features="log2", min_samples_leaf=13, n_estimators=320, criterion="entropy" |
-|                0.9211 | max_features="log2", min_samples_leaf=3, n_estimators=160, criterion="entropy"  |
-|                0.9211 | max_features="log2", min_samples_leaf=3, n_estimators=640, criterion="entropy"  |
-|                0.9211 | max_features="log2", min_samples_leaf=13, n_estimators=20, criterion="gini"     |
-|                0.9209 | max_features="log2", min_samples_leaf=7, n_estimators=320, criterion="gini"     |
-|                0.9207 | max_features="log2", min_samples_leaf=3, n_estimators=320, criterion="gini"     |
-|                0.9205 | max_features="log2", min_samples_leaf=7, n_estimators=80, criterion="entropy"   |
-|                0.9203 | max_features="log2", min_samples_leaf=13, n_estimators=160, criterion="entropy" |
-|                0.9196 | max_features="log2", min_samples_leaf=13, n_estimators=20, criterion="entropy"  |
-|                0.9195 | max_features="log2", min_samples_leaf=7, n_estimators=160, criterion="gini"     |
-|                0.9195 | max_features="log2", min_samples_leaf=3, n_estimators=640, criterion="gini"     |
-|                0.919  | max_features="log2", min_samples_leaf=3, n_estimators=160, criterion="gini"     |
-|                0.9189 | max_features="log2", min_samples_leaf=5, n_estimators=640, criterion="entropy"  |
-|                0.9188 | max_features="log2", min_samples_leaf=13, n_estimators=80, criterion="gini"     |
-|                0.9187 | max_features="log2", min_samples_leaf=5, n_estimators=160, criterion="gini"     |
-|                0.9177 | max_features="log2", min_samples_leaf=5, n_estimators=320, criterion="gini"     |
-|                0.9174 | max_features="log2", min_samples_leaf=5, n_estimators=640, criterion="gini"     |
-|                0.9146 | max_features="log2", min_samples_leaf=13, n_estimators=40, criterion="gini"     |
-|                0.9137 | max_features="log2", min_samples_leaf=7, n_estimators=80, criterion="gini"      |
-|                0.9128 | max_features="log2", min_samples_leaf=5, n_estimators=80, criterion="gini"      |
-
 ## GaussianNB
-| roc_auc.labels.true   | params   |
-||
+|   roc_auc.labels.false | params   |
+|-----------------------:|:---------|
+|                 0.9581 |          |
 
 ## GradientBoosting
-|   roc_auc.labels.true | params                                                                 |
-|----------------------:|:-----------------------------------------------------------------------|
-|                0.984  | max_depth=7, max_features="log2", learning_rate=0.1, n_estimators=700  |
-|                0.9831 | max_depth=7, max_features="log2", learning_rate=0.5, n_estimators=500  |
-|                0.9828 | max_depth=7, max_features="log2", learning_rate=0.5, n_estimators=300  |
-|                0.9817 | max_depth=7, max_features="log2", learning_rate=0.1, n_estimators=500  |
-|                0.9724 | max_depth=5, max_features="log2", learning_rate=0.5, n_estimators=300  |
-|                0.971  | max_depth=7, max_features="log2", learning_rate=0.5, n_estimators=100  |
-|                0.9703 | max_depth=5, max_features="log2", learning_rate=0.5, n_estimators=700  |
-|                0.9665 | max_depth=7, max_features="log2", learning_rate=0.1, n_estimators=300  |
-|                0.9646 | max_depth=5, max_features="log2", learning_rate=0.5, n_estimators=500  |
-|                0.9642 | max_depth=3, max_features="log2", learning_rate=0.5, n_estimators=700  |
-|                0.9582 | max_depth=5, max_features="log2", learning_rate=0.1, n_estimators=700  |
-|                0.9543 | max_depth=7, max_features="log2", learning_rate=1, n_estimators=100    |
-|                0.9442 | max_depth=3, max_features="log2", learning_rate=0.5, n_estimators=500  |
-|                0.9396 | max_depth=5, max_features="log2", learning_rate=0.5, n_estimators=100  |
-|                0.9379 | max_depth=7, max_features="log2", learning_rate=0.5, n_estimators=700  |
-|                0.9368 | max_depth=5, max_features="log2", learning_rate=0.1, n_estimators=500  |
-|                0.9336 | max_depth=1, max_features="log2", learning_rate=0.1, n_estimators=500  |
-|                0.9329 | max_depth=5, max_features="log2", learning_rate=1, n_estimators=300    |
-|                0.932  | max_depth=1, max_features="log2", learning_rate=0.1, n_estimators=700  |
-|                0.932  | max_depth=1, max_features="log2", learning_rate=0.1, n_estimators=300  |
-|                0.9319 | max_depth=3, max_features="log2", learning_rate=0.1, n_estimators=100  |
-|                0.9298 | max_depth=5, max_features="log2", learning_rate=1, n_estimators=100    |
-|                0.9292 | max_depth=3, max_features="log2", learning_rate=0.5, n_estimators=300  |
-|                0.9292 | max_depth=5, max_features="log2", learning_rate=0.01, n_estimators=700 |
-|                0.9274 | max_depth=3, max_features="log2", learning_rate=0.01, n_estimators=700 |
-|                0.9258 | max_depth=5, max_features="log2", learning_rate=0.01, n_estimators=300 |
-|                0.9255 | max_depth=3, max_features="log2", learning_rate=0.01, n_estimators=500 |
-|                0.9251 | max_depth=5, max_features="log2", learning_rate=0.01, n_estimators=500 |
-|                0.9238 | max_depth=1, max_features="log2", learning_rate=0.5, n_estimators=500  |
-|                0.9231 | max_depth=7, max_features="log2", learning_rate=0.01, n_estimators=500 |
-|                0.9225 | max_depth=1, max_features="log2", learning_rate=0.5, n_estimators=300  |
-|                0.9218 | max_depth=1, max_features="log2", learning_rate=0.5, n_estimators=100  |
-|                0.9218 | max_depth=3, max_features="log2", learning_rate=0.01, n_estimators=300 |
-|                0.9217 | max_depth=7, max_features="log2", learning_rate=0.01, n_estimators=300 |
-|                0.9216 | max_depth=1, max_features="log2", learning_rate=0.1, n_estimators=100  |
-|                0.9211 | max_depth=5, max_features="log2", learning_rate=0.1, n_estimators=100  |
-|                0.921  | max_depth=3, max_features="log2", learning_rate=0.1, n_estimators=300  |
-|                0.9208 | max_depth=7, max_features="log2", learning_rate=0.01, n_estimators=700 |
-|                0.9202 | max_depth=1, max_features="log2", learning_rate=0.5, n_estimators=700  |
-|                0.9196 | max_depth=7, max_features="log2", learning_rate=0.01, n_estimators=100 |
-|                0.9191 | max_depth=5, max_features="log2", learning_rate=0.01, n_estimators=100 |
-|                0.9189 | max_depth=3, max_features="log2", learning_rate=0.1, n_estimators=500  |
-|                0.9183 | max_depth=3, max_features="log2", learning_rate=0.01, n_estimators=100 |
-|                0.9174 | max_depth=3, max_features="log2", learning_rate=1, n_estimators=700    |
-|                0.9165 | max_depth=7, max_features="log2", learning_rate=0.1, n_estimators=100  |
-|                0.9158 | max_depth=1, max_features="log2", learning_rate=0.01, n_estimators=700 |
-|                0.9141 | max_depth=1, max_features="log2", learning_rate=0.01, n_estimators=500 |
-|                0.9139 | max_depth=3, max_features="log2", learning_rate=0.1, n_estimators=700  |
-|                0.9134 | max_depth=5, max_features="log2", learning_rate=0.1, n_estimators=300  |
-|                0.911  | max_depth=1, max_features="log2", learning_rate=0.01, n_estimators=300 |
-|                0.906  | max_depth=7, max_features="log2", learning_rate=1, n_estimators=500    |
-|                0.8977 | max_depth=1, max_features="log2", learning_rate=0.01, n_estimators=100 |
-|                0.896  | max_depth=3, max_features="log2", learning_rate=0.5, n_estimators=100  |
-|                0.8946 | max_depth=5, max_features="log2", learning_rate=1, n_estimators=700    |
-|                0.8897 | max_depth=3, max_features="log2", learning_rate=1, n_estimators=300    |
-|                0.8848 | max_depth=1, max_features="log2", learning_rate=1, n_estimators=300    |
-|                0.8685 | max_depth=1, max_features="log2", learning_rate=1, n_estimators=700    |
-|                0.828  | max_depth=3, max_features="log2", learning_rate=1, n_estimators=500    |
-|                0.8277 | max_depth=7, max_features="log2", learning_rate=1, n_estimators=700    |
-|                0.8225 | max_depth=7, max_features="log2", learning_rate=1, n_estimators=300    |
-|                0.8046 | max_depth=3, max_features="log2", learning_rate=1, n_estimators=100    |
-|                0.7951 | max_depth=5, max_features="log2", learning_rate=1, n_estimators=500    |
-|                0.7879 | max_depth=1, max_features="log2", learning_rate=1, n_estimators=500    |
-|                0.7775 | max_depth=1, max_features="log2", learning_rate=1, n_estimators=100    |
+|   roc_auc.labels.false | params                                                                                      |
+|-----------------------:|:--------------------------------------------------------------------------------------------|
+|                 0.9637 | max_features="log2", max_depth=1, min_samples_leaf=1, learning_rate=0.1, n_estimators=700   |
+|                 0.9635 | max_features="log2", max_depth=1, min_samples_leaf=5, learning_rate=0.1, n_estimators=700   |
+|                 0.9633 | max_features="log2", max_depth=1, min_samples_leaf=1, learning_rate=0.1, n_estimators=500   |
+|                 0.9629 | max_features="log2", max_depth=1, min_samples_leaf=13, learning_rate=0.1, n_estimators=500  |
+|                 0.9629 | max_features="log2", max_depth=1, min_samples_leaf=5, learning_rate=0.1, n_estimators=500   |
+|                 0.9628 | max_features="log2", max_depth=1, min_samples_leaf=3, learning_rate=0.1, n_estimators=700   |
+|                 0.9626 | max_features="log2", max_depth=1, min_samples_leaf=7, learning_rate=0.1, n_estimators=700   |
+|                 0.9626 | max_features="log2", max_depth=3, min_samples_leaf=13, learning_rate=0.1, n_estimators=100  |
+|                 0.9625 | max_features="log2", max_depth=1, min_samples_leaf=3, learning_rate=0.1, n_estimators=500   |
+|                 0.9623 | max_features="log2", max_depth=1, min_samples_leaf=13, learning_rate=0.1, n_estimators=700  |
+|                 0.9621 | max_features="log2", max_depth=5, min_samples_leaf=1, learning_rate=0.1, n_estimators=100   |
+|                 0.9621 | max_features="log2", max_depth=5, min_samples_leaf=3, learning_rate=0.01, n_estimators=700  |
+|                 0.9621 | max_features="log2", max_depth=1, min_samples_leaf=13, learning_rate=0.5, n_estimators=300  |
+|                 0.9619 | max_features="log2", max_depth=1, min_samples_leaf=7, learning_rate=0.5, n_estimators=300   |
+|                 0.9619 | max_features="log2", max_depth=5, min_samples_leaf=5, learning_rate=0.01, n_estimators=700  |
+|                 0.9617 | max_features="log2", max_depth=1, min_samples_leaf=3, learning_rate=0.5, n_estimators=300   |
+|                 0.9617 | max_features="log2", max_depth=5, min_samples_leaf=5, learning_rate=0.01, n_estimators=500  |
+|                 0.9615 | max_features="log2", max_depth=5, min_samples_leaf=13, learning_rate=0.1, n_estimators=100  |
+|                 0.9614 | max_features="log2", max_depth=1, min_samples_leaf=7, learning_rate=0.1, n_estimators=500   |
+|                 0.9614 | max_features="log2", max_depth=5, min_samples_leaf=13, learning_rate=0.01, n_estimators=700 |
+|                 0.9613 | max_features="log2", max_depth=5, min_samples_leaf=1, learning_rate=0.01, n_estimators=700  |
+|                 0.9612 | max_features="log2", max_depth=3, min_samples_leaf=1, learning_rate=0.1, n_estimators=300   |
+|                 0.961  | max_features="log2", max_depth=7, min_samples_leaf=7, learning_rate=0.01, n_estimators=500  |
+|                 0.961  | max_features="log2", max_depth=5, min_samples_leaf=5, learning_rate=0.1, n_estimators=100   |
+|                 0.9609 | max_features="log2", max_depth=7, min_samples_leaf=7, learning_rate=0.01, n_estimators=700  |
+|                 0.9607 | max_features="log2", max_depth=3, min_samples_leaf=5, learning_rate=0.1, n_estimators=300   |
+|                 0.9607 | max_features="log2", max_depth=5, min_samples_leaf=3, learning_rate=0.1, n_estimators=100   |
+|                 0.9607 | max_features="log2", max_depth=5, min_samples_leaf=13, learning_rate=0.01, n_estimators=500 |
+|                 0.9606 | max_features="log2", max_depth=7, min_samples_leaf=13, learning_rate=0.01, n_estimators=500 |
+|                 0.9605 | max_features="log2", max_depth=7, min_samples_leaf=3, learning_rate=0.01, n_estimators=700  |
+|                 0.9604 | max_features="log2", max_depth=7, min_samples_leaf=13, learning_rate=0.01, n_estimators=700 |
+|                 0.9604 | max_features="log2", max_depth=3, min_samples_leaf=7, learning_rate=0.1, n_estimators=300   |
+|                 0.9603 | max_features="log2", max_depth=5, min_samples_leaf=7, learning_rate=0.1, n_estimators=100   |
+|                 0.9603 | max_features="log2", max_depth=3, min_samples_leaf=7, learning_rate=0.1, n_estimators=100   |
+|                 0.9603 | max_features="log2", max_depth=5, min_samples_leaf=3, learning_rate=0.01, n_estimators=500  |
+|                 0.9603 | max_features="log2", max_depth=3, min_samples_leaf=3, learning_rate=0.1, n_estimators=100   |
+|                 0.9603 | max_features="log2", max_depth=7, min_samples_leaf=5, learning_rate=0.01, n_estimators=500  |
+|                 0.9602 | max_features="log2", max_depth=5, min_samples_leaf=1, learning_rate=0.01, n_estimators=500  |
+|                 0.9602 | max_features="log2", max_depth=5, min_samples_leaf=7, learning_rate=0.01, n_estimators=700  |
+|                 0.9602 | max_features="log2", max_depth=1, min_samples_leaf=1, learning_rate=0.5, n_estimators=300   |
+|                 0.9601 | max_features="log2", max_depth=3, min_samples_leaf=3, learning_rate=0.1, n_estimators=300   |
+|                 0.9601 | max_features="log2", max_depth=7, min_samples_leaf=13, learning_rate=0.01, n_estimators=300 |
+|                 0.9599 | max_features="log2", max_depth=5, min_samples_leaf=7, learning_rate=0.01, n_estimators=500  |
+|                 0.9597 | max_features="log2", max_depth=7, min_samples_leaf=5, learning_rate=0.01, n_estimators=700  |
+|                 0.9596 | max_features="log2", max_depth=7, min_samples_leaf=5, learning_rate=0.1, n_estimators=100   |
+|                 0.9595 | max_features="log2", max_depth=1, min_samples_leaf=1, learning_rate=0.5, n_estimators=500   |
+|                 0.9594 | max_features="log2", max_depth=5, min_samples_leaf=13, learning_rate=0.01, n_estimators=300 |
+|                 0.9593 | max_features="log2", max_depth=1, min_samples_leaf=5, learning_rate=0.5, n_estimators=500   |
+|                 0.9593 | max_features="log2", max_depth=1, min_samples_leaf=7, learning_rate=0.1, n_estimators=300   |
+|                 0.9593 | max_features="log2", max_depth=1, min_samples_leaf=5, learning_rate=0.1, n_estimators=300   |
+|                 0.9592 | max_features="log2", max_depth=1, min_samples_leaf=5, learning_rate=0.5, n_estimators=300   |
+|                 0.9592 | max_features="log2", max_depth=3, min_samples_leaf=13, learning_rate=0.1, n_estimators=500  |
+|                 0.9591 | max_features="log2", max_depth=1, min_samples_leaf=7, learning_rate=0.5, n_estimators=100   |
+|                 0.9591 | max_features="log2", max_depth=3, min_samples_leaf=1, learning_rate=0.1, n_estimators=100   |
+|                 0.9591 | max_features="log2", max_depth=3, min_samples_leaf=13, learning_rate=0.1, n_estimators=300  |
+|                 0.9591 | max_features="log2", max_depth=1, min_samples_leaf=1, learning_rate=0.1, n_estimators=300   |
+|                 0.959  | max_features="log2", max_depth=7, min_samples_leaf=3, learning_rate=0.01, n_estimators=500  |
+|                 0.959  | max_features="log2", max_depth=1, min_samples_leaf=7, learning_rate=0.5, n_estimators=500   |
+|                 0.9589 | max_features="log2", max_depth=7, min_samples_leaf=1, learning_rate=0.01, n_estimators=700  |
+|                 0.9587 | max_features="log2", max_depth=3, min_samples_leaf=7, learning_rate=0.01, n_estimators=700  |
+|                 0.9587 | max_features="log2", max_depth=1, min_samples_leaf=13, learning_rate=0.5, n_estimators=700  |
+|                 0.9585 | max_features="log2", max_depth=7, min_samples_leaf=1, learning_rate=0.01, n_estimators=500  |
+|                 0.9585 | max_features="log2", max_depth=3, min_samples_leaf=1, learning_rate=0.01, n_estimators=700  |
+|                 0.9585 | max_features="log2", max_depth=3, min_samples_leaf=3, learning_rate=0.01, n_estimators=700  |
+|                 0.9584 | max_features="log2", max_depth=1, min_samples_leaf=13, learning_rate=0.5, n_estimators=500  |
+|                 0.9584 | max_features="log2", max_depth=3, min_samples_leaf=13, learning_rate=0.01, n_estimators=700 |
+|                 0.9582 | max_features="log2", max_depth=3, min_samples_leaf=5, learning_rate=0.01, n_estimators=700  |
+|                 0.9582 | max_features="log2", max_depth=3, min_samples_leaf=1, learning_rate=0.1, n_estimators=500   |
+|                 0.9582 | max_features="log2", max_depth=1, min_samples_leaf=3, learning_rate=0.5, n_estimators=500   |
+|                 0.958  | max_features="log2", max_depth=1, min_samples_leaf=7, learning_rate=0.5, n_estimators=700   |
+|                 0.958  | max_features="log2", max_depth=3, min_samples_leaf=5, learning_rate=0.1, n_estimators=100   |
+|                 0.958  | max_features="log2", max_depth=1, min_samples_leaf=3, learning_rate=0.5, n_estimators=700   |
+|                 0.958  | max_features="log2", max_depth=1, min_samples_leaf=13, learning_rate=0.1, n_estimators=300  |
+|                 0.9579 | max_features="log2", max_depth=1, min_samples_leaf=3, learning_rate=0.1, n_estimators=300   |
+|                 0.9578 | max_features="log2", max_depth=7, min_samples_leaf=7, learning_rate=0.01, n_estimators=300  |
+|                 0.9577 | max_features="log2", max_depth=1, min_samples_leaf=1, learning_rate=0.5, n_estimators=100   |
+|                 0.9575 | max_features="log2", max_depth=7, min_samples_leaf=5, learning_rate=0.01, n_estimators=300  |
+|                 0.9575 | max_features="log2", max_depth=5, min_samples_leaf=1, learning_rate=0.01, n_estimators=300  |
+|                 0.9574 | max_features="log2", max_depth=3, min_samples_leaf=5, learning_rate=0.1, n_estimators=500   |
+|                 0.9574 | max_features="log2", max_depth=3, min_samples_leaf=3, learning_rate=0.01, n_estimators=500  |
+|                 0.9573 | max_features="log2", max_depth=7, min_samples_leaf=1, learning_rate=0.01, n_estimators=300  |
+|                 0.9573 | max_features="log2", max_depth=7, min_samples_leaf=3, learning_rate=0.01, n_estimators=300  |
+|                 0.9572 | max_features="log2", max_depth=3, min_samples_leaf=5, learning_rate=0.01, n_estimators=500  |
+|                 0.9572 | max_features="log2", max_depth=3, min_samples_leaf=1, learning_rate=0.01, n_estimators=500  |
+|                 0.957  | max_features="log2", max_depth=5, min_samples_leaf=5, learning_rate=0.01, n_estimators=300  |
+|                 0.9569 | max_features="log2", max_depth=3, min_samples_leaf=7, learning_rate=0.01, n_estimators=500  |
+|                 0.9569 | max_features="log2", max_depth=1, min_samples_leaf=1, learning_rate=0.5, n_estimators=700   |
+|                 0.9568 | max_features="log2", max_depth=3, min_samples_leaf=13, learning_rate=0.01, n_estimators=500 |
+|                 0.9565 | max_features="log2", max_depth=7, min_samples_leaf=13, learning_rate=0.1, n_estimators=100  |
+|                 0.9564 | max_features="log2", max_depth=5, min_samples_leaf=7, learning_rate=0.01, n_estimators=300  |
+|                 0.9564 | max_features="log2", max_depth=5, min_samples_leaf=3, learning_rate=0.01, n_estimators=300  |
+|                 0.9562 | max_features="log2", max_depth=3, min_samples_leaf=7, learning_rate=0.1, n_estimators=500   |
+|                 0.9562 | max_features="log2", max_depth=3, min_samples_leaf=5, learning_rate=0.1, n_estimators=700   |
+|                 0.9561 | max_features="log2", max_depth=7, min_samples_leaf=13, learning_rate=0.01, n_estimators=100 |
+|                 0.9559 | max_features="log2", max_depth=7, min_samples_leaf=1, learning_rate=0.1, n_estimators=100   |
+|                 0.9558 | max_features="log2", max_depth=7, min_samples_leaf=7, learning_rate=0.1, n_estimators=100   |
+|                 0.9558 | max_features="log2", max_depth=7, min_samples_leaf=3, learning_rate=0.01, n_estimators=100  |
+|                 0.9558 | max_features="log2", max_depth=1, min_samples_leaf=5, learning_rate=0.5, n_estimators=100   |
+|                 0.9557 | max_features="log2", max_depth=3, min_samples_leaf=3, learning_rate=0.1, n_estimators=500   |
+|                 0.9553 | max_features="log2", max_depth=5, min_samples_leaf=13, learning_rate=0.1, n_estimators=300  |
+|                 0.9553 | max_features="log2", max_depth=1, min_samples_leaf=3, learning_rate=0.5, n_estimators=100   |
+|                 0.9552 | max_features="log2", max_depth=1, min_samples_leaf=5, learning_rate=0.5, n_estimators=700   |
+|                 0.9552 | max_features="log2", max_depth=7, min_samples_leaf=3, learning_rate=0.1, n_estimators=100   |
+|                 0.9551 | max_features="log2", max_depth=7, min_samples_leaf=5, learning_rate=0.01, n_estimators=100  |
+|                 0.9547 | max_features="log2", max_depth=3, min_samples_leaf=13, learning_rate=0.01, n_estimators=300 |
+|                 0.9544 | max_features="log2", max_depth=3, min_samples_leaf=3, learning_rate=0.01, n_estimators=300  |
+|                 0.9544 | max_features="log2", max_depth=3, min_samples_leaf=1, learning_rate=0.1, n_estimators=700   |
+|                 0.9544 | max_features="log2", max_depth=3, min_samples_leaf=1, learning_rate=0.01, n_estimators=300  |
+|                 0.9544 | max_features="log2", max_depth=3, min_samples_leaf=7, learning_rate=0.01, n_estimators=300  |
+|                 0.9542 | max_features="log2", max_depth=3, min_samples_leaf=5, learning_rate=0.01, n_estimators=300  |
+|                 0.9538 | max_features="log2", max_depth=1, min_samples_leaf=13, learning_rate=0.5, n_estimators=100  |
+|                 0.9537 | max_features="log2", max_depth=5, min_samples_leaf=13, learning_rate=0.01, n_estimators=100 |
+|                 0.9535 | max_features="log2", max_depth=3, min_samples_leaf=7, learning_rate=0.1, n_estimators=700   |
+|                 0.9531 | max_features="log2", max_depth=7, min_samples_leaf=7, learning_rate=0.01, n_estimators=100  |
+|                 0.9528 | max_features="log2", max_depth=3, min_samples_leaf=13, learning_rate=0.1, n_estimators=700  |
+|                 0.9527 | max_features="log2", max_depth=5, min_samples_leaf=7, learning_rate=0.01, n_estimators=100  |
+|                 0.9526 | max_features="log2", max_depth=3, min_samples_leaf=3, learning_rate=0.1, n_estimators=700   |
+|                 0.9526 | max_features="log2", max_depth=1, min_samples_leaf=13, learning_rate=0.1, n_estimators=100  |
+|                 0.9519 | max_features="log2", max_depth=1, min_samples_leaf=5, learning_rate=0.01, n_estimators=700  |
+|                 0.9519 | max_features="log2", max_depth=1, min_samples_leaf=7, learning_rate=0.01, n_estimators=700  |
+|                 0.9519 | max_features="log2", max_depth=1, min_samples_leaf=1, learning_rate=0.01, n_estimators=700  |
+|                 0.9519 | max_features="log2", max_depth=1, min_samples_leaf=3, learning_rate=0.01, n_estimators=700  |
+|                 0.9518 | max_features="log2", max_depth=5, min_samples_leaf=3, learning_rate=0.01, n_estimators=100  |
+|                 0.9518 | max_features="log2", max_depth=1, min_samples_leaf=13, learning_rate=0.01, n_estimators=700 |
+|                 0.9517 | max_features="log2", max_depth=1, min_samples_leaf=7, learning_rate=0.1, n_estimators=100   |
+|                 0.9512 | max_features="log2", max_depth=1, min_samples_leaf=5, learning_rate=0.1, n_estimators=100   |
+|                 0.9512 | max_features="log2", max_depth=7, min_samples_leaf=1, learning_rate=0.01, n_estimators=100  |
+|                 0.9511 | max_features="log2", max_depth=3, min_samples_leaf=3, learning_rate=0.5, n_estimators=100   |
+|                 0.9507 | max_features="log2", max_depth=5, min_samples_leaf=5, learning_rate=0.01, n_estimators=100  |
+|                 0.9506 | max_features="log2", max_depth=5, min_samples_leaf=1, learning_rate=0.1, n_estimators=300   |
+|                 0.9501 | max_features="log2", max_depth=5, min_samples_leaf=5, learning_rate=0.1, n_estimators=300   |
+|                 0.9492 | max_features="log2", max_depth=1, min_samples_leaf=1, learning_rate=0.1, n_estimators=100   |
+|                 0.9492 | max_features="log2", max_depth=1, min_samples_leaf=3, learning_rate=0.1, n_estimators=100   |
+|                 0.9492 | max_features="log2", max_depth=5, min_samples_leaf=3, learning_rate=0.1, n_estimators=300   |
+|                 0.9488 | max_features="log2", max_depth=1, min_samples_leaf=1, learning_rate=0.01, n_estimators=500  |
+|                 0.9488 | max_features="log2", max_depth=1, min_samples_leaf=3, learning_rate=0.01, n_estimators=500  |
+|                 0.9487 | max_features="log2", max_depth=1, min_samples_leaf=5, learning_rate=0.01, n_estimators=500  |
+|                 0.9487 | max_features="log2", max_depth=1, min_samples_leaf=7, learning_rate=0.01, n_estimators=500  |
+|                 0.9487 | max_features="log2", max_depth=1, min_samples_leaf=13, learning_rate=0.01, n_estimators=500 |
+|                 0.9487 | max_features="log2", max_depth=5, min_samples_leaf=1, learning_rate=0.01, n_estimators=100  |
+|                 0.9485 | max_features="log2", max_depth=5, min_samples_leaf=7, learning_rate=0.1, n_estimators=300   |
+|                 0.9481 | max_features="log2", max_depth=3, min_samples_leaf=13, learning_rate=0.01, n_estimators=100 |
+|                 0.9477 | max_features="log2", max_depth=3, min_samples_leaf=5, learning_rate=0.01, n_estimators=100  |
+|                 0.9476 | max_features="log2", max_depth=3, min_samples_leaf=3, learning_rate=0.01, n_estimators=100  |
+|                 0.9476 | max_features="log2", max_depth=3, min_samples_leaf=1, learning_rate=0.01, n_estimators=100  |
+|                 0.9472 | max_features="log2", max_depth=3, min_samples_leaf=7, learning_rate=0.01, n_estimators=100  |
+|                 0.9458 | max_features="log2", max_depth=1, min_samples_leaf=1, learning_rate=0.01, n_estimators=300  |
+|                 0.9458 | max_features="log2", max_depth=1, min_samples_leaf=3, learning_rate=0.01, n_estimators=300  |
+|                 0.9458 | max_features="log2", max_depth=1, min_samples_leaf=5, learning_rate=0.01, n_estimators=300  |
+|                 0.9458 | max_features="log2", max_depth=1, min_samples_leaf=7, learning_rate=0.01, n_estimators=300  |
+|                 0.9458 | max_features="log2", max_depth=1, min_samples_leaf=13, learning_rate=0.01, n_estimators=300 |
+|                 0.9453 | max_features="log2", max_depth=1, min_samples_leaf=1, learning_rate=0.01, n_estimators=100  |
+|                 0.9453 | max_features="log2", max_depth=1, min_samples_leaf=3, learning_rate=0.01, n_estimators=100  |
+|                 0.9453 | max_features="log2", max_depth=1, min_samples_leaf=5, learning_rate=0.01, n_estimators=100  |
+|                 0.9453 | max_features="log2", max_depth=1, min_samples_leaf=7, learning_rate=0.01, n_estimators=100  |
+|                 0.9453 | max_features="log2", max_depth=1, min_samples_leaf=13, learning_rate=0.01, n_estimators=100 |
+|                 0.9438 | max_features="log2", max_depth=3, min_samples_leaf=13, learning_rate=0.5, n_estimators=100  |
+|                 0.942  | max_features="log2", max_depth=3, min_samples_leaf=1, learning_rate=0.5, n_estimators=100   |
+|                 0.9374 | max_features="log2", max_depth=3, min_samples_leaf=5, learning_rate=0.5, n_estimators=100   |
+|                 0.9361 | max_features="log2", max_depth=3, min_samples_leaf=7, learning_rate=0.5, n_estimators=100   |
+|                 0.9332 | max_features="log2", max_depth=5, min_samples_leaf=7, learning_rate=0.1, n_estimators=500   |
+|                 0.9324 | max_features="log2", max_depth=5, min_samples_leaf=5, learning_rate=0.1, n_estimators=500   |
+|                 0.9293 | max_features="log2", max_depth=5, min_samples_leaf=1, learning_rate=0.1, n_estimators=500   |
+|                 0.927  | max_features="log2", max_depth=1, min_samples_leaf=5, learning_rate=1, n_estimators=100     |
+|                 0.9258 | max_features="log2", max_depth=5, min_samples_leaf=13, learning_rate=0.1, n_estimators=500  |
+|                 0.923  | max_features="log2", max_depth=5, min_samples_leaf=3, learning_rate=0.1, n_estimators=500   |
+|                 0.9143 | max_features="log2", max_depth=3, min_samples_leaf=5, learning_rate=0.5, n_estimators=300   |
+|                 0.9134 | max_features="log2", max_depth=1, min_samples_leaf=5, learning_rate=1, n_estimators=300     |
+|                 0.9118 | max_features="log2", max_depth=3, min_samples_leaf=7, learning_rate=0.5, n_estimators=300   |
+|                 0.9115 | max_features="log2", max_depth=1, min_samples_leaf=7, learning_rate=1, n_estimators=100     |
+|                 0.9115 | max_features="log2", max_depth=3, min_samples_leaf=13, learning_rate=0.5, n_estimators=300  |
+|                 0.9114 | max_features="log2", max_depth=7, min_samples_leaf=13, learning_rate=0.1, n_estimators=300  |
+|                 0.9111 | max_features="log2", max_depth=1, min_samples_leaf=7, learning_rate=1, n_estimators=500     |
+|                 0.9108 | max_features="log2", max_depth=3, min_samples_leaf=3, learning_rate=0.5, n_estimators=300   |
+|                 0.9063 | max_features="log2", max_depth=5, min_samples_leaf=1, learning_rate=0.1, n_estimators=700   |
+|                 0.9056 | max_features="log2", max_depth=5, min_samples_leaf=13, learning_rate=0.1, n_estimators=700  |
+|                 0.9051 | max_features="log2", max_depth=3, min_samples_leaf=1, learning_rate=0.5, n_estimators=300   |
+|                 0.9044 | max_features="log2", max_depth=5, min_samples_leaf=5, learning_rate=0.5, n_estimators=100   |
+|                 0.9044 | max_features="log2", max_depth=5, min_samples_leaf=13, learning_rate=0.5, n_estimators=100  |
+|                 0.9035 | max_features="log2", max_depth=5, min_samples_leaf=1, learning_rate=0.5, n_estimators=100   |
+|                 0.9023 | max_features="log2", max_depth=1, min_samples_leaf=13, learning_rate=1, n_estimators=500    |
+|                 0.9017 | max_features="log2", max_depth=7, min_samples_leaf=5, learning_rate=0.1, n_estimators=300   |
+|                 0.9011 | max_features="log2", max_depth=7, min_samples_leaf=3, learning_rate=0.1, n_estimators=300   |
+|                 0.9009 | max_features="log2", max_depth=1, min_samples_leaf=3, learning_rate=1, n_estimators=100     |
+|                 0.9004 | max_features="log2", max_depth=7, min_samples_leaf=1, learning_rate=0.1, n_estimators=300   |
+|                 0.8994 | max_features="log2", max_depth=7, min_samples_leaf=7, learning_rate=0.1, n_estimators=300   |
+|                 0.8991 | max_features="log2", max_depth=5, min_samples_leaf=3, learning_rate=0.1, n_estimators=700   |
+|                 0.8989 | max_features="log2", max_depth=5, min_samples_leaf=7, learning_rate=0.5, n_estimators=100   |
+|                 0.8978 | max_features="log2", max_depth=5, min_samples_leaf=3, learning_rate=0.5, n_estimators=100   |
+|                 0.8976 | max_features="log2", max_depth=5, min_samples_leaf=5, learning_rate=0.1, n_estimators=700   |
+|                 0.8957 | max_features="log2", max_depth=1, min_samples_leaf=5, learning_rate=1, n_estimators=500     |
+|                 0.8927 | max_features="log2", max_depth=5, min_samples_leaf=7, learning_rate=0.1, n_estimators=700   |
+|                 0.8841 | max_features="log2", max_depth=3, min_samples_leaf=7, learning_rate=0.5, n_estimators=500   |
+|                 0.8829 | max_features="log2", max_depth=3, min_samples_leaf=3, learning_rate=0.5, n_estimators=500   |
+|                 0.8745 | max_features="log2", max_depth=3, min_samples_leaf=5, learning_rate=0.5, n_estimators=500   |
+|                 0.8734 | max_features="log2", max_depth=7, min_samples_leaf=7, learning_rate=0.1, n_estimators=700   |
+|                 0.8724 | max_features="log2", max_depth=3, min_samples_leaf=1, learning_rate=0.5, n_estimators=500   |
+|                 0.8716 | max_features="log2", max_depth=7, min_samples_leaf=3, learning_rate=0.1, n_estimators=500   |
+|                 0.8713 | max_features="log2", max_depth=7, min_samples_leaf=7, learning_rate=0.1, n_estimators=500   |
+|                 0.8709 | max_features="log2", max_depth=3, min_samples_leaf=13, learning_rate=0.5, n_estimators=500  |
+|                 0.8699 | max_features="log2", max_depth=7, min_samples_leaf=13, learning_rate=0.1, n_estimators=500  |
+|                 0.8681 | max_features="log2", max_depth=7, min_samples_leaf=13, learning_rate=0.1, n_estimators=700  |
+|                 0.8659 | max_features="log2", max_depth=7, min_samples_leaf=1, learning_rate=0.1, n_estimators=700   |
+|                 0.8648 | max_features="log2", max_depth=7, min_samples_leaf=1, learning_rate=0.1, n_estimators=500   |
+|                 0.8645 | max_features="log2", max_depth=7, min_samples_leaf=5, learning_rate=0.1, n_estimators=500   |
+|                 0.8633 | max_features="log2", max_depth=3, min_samples_leaf=13, learning_rate=0.5, n_estimators=700  |
+|                 0.8603 | max_features="log2", max_depth=3, min_samples_leaf=1, learning_rate=0.5, n_estimators=700   |
+|                 0.86   | max_features="log2", max_depth=7, min_samples_leaf=3, learning_rate=0.1, n_estimators=700   |
+|                 0.86   | max_features="log2", max_depth=7, min_samples_leaf=5, learning_rate=0.1, n_estimators=700   |
+|                 0.8578 | max_features="log2", max_depth=3, min_samples_leaf=3, learning_rate=0.5, n_estimators=700   |
+|                 0.8532 | max_features="log2", max_depth=7, min_samples_leaf=1, learning_rate=0.5, n_estimators=700   |
+|                 0.8484 | max_features="log2", max_depth=3, min_samples_leaf=3, learning_rate=1, n_estimators=100     |
+|                 0.8465 | max_features="log2", max_depth=3, min_samples_leaf=13, learning_rate=1, n_estimators=100    |
+|                 0.8464 | max_features="log2", max_depth=5, min_samples_leaf=3, learning_rate=0.5, n_estimators=500   |
+|                 0.8447 | max_features="log2", max_depth=7, min_samples_leaf=5, learning_rate=0.5, n_estimators=300   |
+|                 0.8442 | max_features="log2", max_depth=3, min_samples_leaf=7, learning_rate=0.5, n_estimators=700   |
+|                 0.8425 | max_features="log2", max_depth=7, min_samples_leaf=7, learning_rate=0.5, n_estimators=500   |
+|                 0.8416 | max_features="log2", max_depth=5, min_samples_leaf=5, learning_rate=0.5, n_estimators=500   |
+|                 0.8415 | max_features="log2", max_depth=5, min_samples_leaf=13, learning_rate=0.5, n_estimators=300  |
+|                 0.8411 | max_features="log2", max_depth=7, min_samples_leaf=7, learning_rate=0.5, n_estimators=300   |
+|                 0.8411 | max_features="log2", max_depth=7, min_samples_leaf=3, learning_rate=0.5, n_estimators=100   |
+|                 0.841  | max_features="log2", max_depth=7, min_samples_leaf=5, learning_rate=0.5, n_estimators=700   |
+|                 0.8402 | max_features="log2", max_depth=5, min_samples_leaf=1, learning_rate=0.5, n_estimators=500   |
+|                 0.84   | max_features="log2", max_depth=5, min_samples_leaf=13, learning_rate=0.5, n_estimators=700  |
+|                 0.8384 | max_features="log2", max_depth=5, min_samples_leaf=1, learning_rate=0.5, n_estimators=700   |
+|                 0.8383 | max_features="log2", max_depth=7, min_samples_leaf=5, learning_rate=0.5, n_estimators=500   |
+|                 0.8378 | max_features="log2", max_depth=7, min_samples_leaf=5, learning_rate=0.5, n_estimators=100   |
+|                 0.8378 | max_features="log2", max_depth=5, min_samples_leaf=5, learning_rate=0.5, n_estimators=300   |
+|                 0.8372 | max_features="log2", max_depth=1, min_samples_leaf=13, learning_rate=1, n_estimators=700    |
+|                 0.8368 | max_features="log2", max_depth=5, min_samples_leaf=7, learning_rate=0.5, n_estimators=500   |
+|                 0.8367 | max_features="log2", max_depth=5, min_samples_leaf=5, learning_rate=0.5, n_estimators=700   |
+|                 0.8366 | max_features="log2", max_depth=7, min_samples_leaf=1, learning_rate=0.5, n_estimators=100   |
+|                 0.8362 | max_features="log2", max_depth=3, min_samples_leaf=5, learning_rate=0.5, n_estimators=700   |
+|                 0.8354 | max_features="log2", max_depth=5, min_samples_leaf=13, learning_rate=0.5, n_estimators=500  |
+|                 0.835  | max_features="log2", max_depth=7, min_samples_leaf=13, learning_rate=0.5, n_estimators=500  |
+|                 0.8337 | max_features="log2", max_depth=5, min_samples_leaf=3, learning_rate=0.5, n_estimators=300   |
+|                 0.8333 | max_features="log2", max_depth=7, min_samples_leaf=3, learning_rate=0.5, n_estimators=700   |
+|                 0.8327 | max_features="log2", max_depth=7, min_samples_leaf=3, learning_rate=0.5, n_estimators=500   |
+|                 0.8326 | max_features="log2", max_depth=5, min_samples_leaf=7, learning_rate=0.5, n_estimators=300   |
+|                 0.8317 | max_features="log2", max_depth=7, min_samples_leaf=7, learning_rate=0.5, n_estimators=700   |
+|                 0.8304 | max_features="log2", max_depth=1, min_samples_leaf=3, learning_rate=1, n_estimators=300     |
+|                 0.8301 | max_features="log2", max_depth=5, min_samples_leaf=7, learning_rate=0.5, n_estimators=700   |
+|                 0.8296 | max_features="log2", max_depth=5, min_samples_leaf=3, learning_rate=0.5, n_estimators=700   |
+|                 0.8284 | max_features="log2", max_depth=7, min_samples_leaf=1, learning_rate=0.5, n_estimators=300   |
+|                 0.8275 | max_features="log2", max_depth=3, min_samples_leaf=7, learning_rate=1, n_estimators=100     |
+|                 0.8265 | max_features="log2", max_depth=7, min_samples_leaf=3, learning_rate=0.5, n_estimators=300   |
+|                 0.8263 | max_features="log2", max_depth=7, min_samples_leaf=13, learning_rate=0.5, n_estimators=100  |
+|                 0.8258 | max_features="log2", max_depth=5, min_samples_leaf=1, learning_rate=0.5, n_estimators=300   |
+|                 0.8249 | max_features="log2", max_depth=7, min_samples_leaf=7, learning_rate=0.5, n_estimators=100   |
+|                 0.8194 | max_features="log2", max_depth=1, min_samples_leaf=7, learning_rate=1, n_estimators=700     |
+|                 0.8176 | max_features="log2", max_depth=7, min_samples_leaf=13, learning_rate=0.5, n_estimators=300  |
+|                 0.8168 | max_features="log2", max_depth=7, min_samples_leaf=1, learning_rate=0.5, n_estimators=500   |
+|                 0.812  | max_features="log2", max_depth=1, min_samples_leaf=1, learning_rate=1, n_estimators=500     |
+|                 0.788  | max_features="log2", max_depth=1, min_samples_leaf=13, learning_rate=1, n_estimators=100    |
+|                 0.788  | max_features="log2", max_depth=3, min_samples_leaf=5, learning_rate=1, n_estimators=500     |
+|                 0.788  | max_features="log2", max_depth=5, min_samples_leaf=3, learning_rate=1, n_estimators=300     |
+|                 0.7875 | max_features="log2", max_depth=5, min_samples_leaf=5, learning_rate=1, n_estimators=100     |
+|                 0.7844 | max_features="log2", max_depth=7, min_samples_leaf=13, learning_rate=0.5, n_estimators=700  |
+|                 0.7842 | max_features="log2", max_depth=3, min_samples_leaf=13, learning_rate=1, n_estimators=300    |
+|                 0.7841 | max_features="log2", max_depth=5, min_samples_leaf=7, learning_rate=1, n_estimators=100     |
+|                 0.7833 | max_features="log2", max_depth=3, min_samples_leaf=7, learning_rate=1, n_estimators=300     |
+|                 0.7808 | max_features="log2", max_depth=3, min_samples_leaf=7, learning_rate=1, n_estimators=500     |
+|                 0.7794 | max_features="log2", max_depth=3, min_samples_leaf=13, learning_rate=1, n_estimators=500    |
+|                 0.7794 | max_features="log2", max_depth=3, min_samples_leaf=5, learning_rate=1, n_estimators=100     |
+|                 0.7733 | max_features="log2", max_depth=5, min_samples_leaf=5, learning_rate=1, n_estimators=700     |
+|                 0.7708 | max_features="log2", max_depth=5, min_samples_leaf=3, learning_rate=1, n_estimators=100     |
+|                 0.7689 | max_features="log2", max_depth=1, min_samples_leaf=1, learning_rate=1, n_estimators=700     |
+|                 0.7601 | max_features="log2", max_depth=3, min_samples_leaf=5, learning_rate=1, n_estimators=300     |
+|                 0.7601 | max_features="log2", max_depth=1, min_samples_leaf=7, learning_rate=1, n_estimators=300     |
+|                 0.7529 | max_features="log2", max_depth=1, min_samples_leaf=1, learning_rate=1, n_estimators=300     |
+|                 0.7524 | max_features="log2", max_depth=3, min_samples_leaf=1, learning_rate=1, n_estimators=500     |
+|                 0.7487 | max_features="log2", max_depth=5, min_samples_leaf=13, learning_rate=1, n_estimators=100    |
+|                 0.7463 | max_features="log2", max_depth=1, min_samples_leaf=3, learning_rate=1, n_estimators=700     |
+|                 0.7463 | max_features="log2", max_depth=3, min_samples_leaf=3, learning_rate=1, n_estimators=300     |
+|                 0.7401 | max_features="log2", max_depth=5, min_samples_leaf=7, learning_rate=1, n_estimators=500     |
+|                 0.7396 | max_features="log2", max_depth=3, min_samples_leaf=1, learning_rate=1, n_estimators=300     |
+|                 0.7394 | max_features="log2", max_depth=3, min_samples_leaf=3, learning_rate=1, n_estimators=700     |
+|                 0.7386 | max_features="log2", max_depth=5, min_samples_leaf=13, learning_rate=1, n_estimators=300    |
+|                 0.7363 | max_features="log2", max_depth=5, min_samples_leaf=7, learning_rate=1, n_estimators=300     |
+|                 0.7336 | max_features="log2", max_depth=7, min_samples_leaf=1, learning_rate=1, n_estimators=100     |
+|                 0.7325 | max_features="log2", max_depth=7, min_samples_leaf=5, learning_rate=1, n_estimators=700     |
+|                 0.7306 | max_features="log2", max_depth=5, min_samples_leaf=13, learning_rate=1, n_estimators=700    |
+|                 0.7286 | max_features="log2", max_depth=7, min_samples_leaf=3, learning_rate=1, n_estimators=700     |
+|                 0.7285 | max_features="log2", max_depth=5, min_samples_leaf=1, learning_rate=1, n_estimators=300     |
+|                 0.7213 | max_features="log2", max_depth=7, min_samples_leaf=3, learning_rate=1, n_estimators=100     |
+|                 0.7189 | max_features="log2", max_depth=7, min_samples_leaf=13, learning_rate=1, n_estimators=300    |
+|                 0.718  | max_features="log2", max_depth=3, min_samples_leaf=1, learning_rate=1, n_estimators=700     |
+|                 0.7165 | max_features="log2", max_depth=1, min_samples_leaf=5, learning_rate=1, n_estimators=700     |
+|                 0.7157 | max_features="log2", max_depth=7, min_samples_leaf=7, learning_rate=1, n_estimators=100     |
+|                 0.7151 | max_features="log2", max_depth=7, min_samples_leaf=13, learning_rate=1, n_estimators=100    |
+|                 0.7141 | max_features="log2", max_depth=7, min_samples_leaf=13, learning_rate=1, n_estimators=500    |
+|                 0.7098 | max_features="log2", max_depth=7, min_samples_leaf=3, learning_rate=1, n_estimators=300     |
+|                 0.7097 | max_features="log2", max_depth=5, min_samples_leaf=1, learning_rate=1, n_estimators=500     |
+|                 0.709  | max_features="log2", max_depth=5, min_samples_leaf=3, learning_rate=1, n_estimators=700     |
+|                 0.7085 | max_features="log2", max_depth=7, min_samples_leaf=7, learning_rate=1, n_estimators=300     |
+|                 0.7079 | max_features="log2", max_depth=3, min_samples_leaf=1, learning_rate=1, n_estimators=100     |
+|                 0.7072 | max_features="log2", max_depth=5, min_samples_leaf=1, learning_rate=1, n_estimators=100     |
+|                 0.7045 | max_features="log2", max_depth=5, min_samples_leaf=1, learning_rate=1, n_estimators=700     |
+|                 0.6981 | max_features="log2", max_depth=5, min_samples_leaf=7, learning_rate=1, n_estimators=700     |
+|                 0.694  | max_features="log2", max_depth=7, min_samples_leaf=5, learning_rate=1, n_estimators=100     |
+|                 0.6926 | max_features="log2", max_depth=3, min_samples_leaf=5, learning_rate=1, n_estimators=700     |
+|                 0.6809 | max_features="log2", max_depth=3, min_samples_leaf=3, learning_rate=1, n_estimators=500     |
+|                 0.6728 | max_features="log2", max_depth=5, min_samples_leaf=5, learning_rate=1, n_estimators=300     |
+|                 0.6708 | max_features="log2", max_depth=3, min_samples_leaf=13, learning_rate=1, n_estimators=700    |
+|                 0.6647 | max_features="log2", max_depth=7, min_samples_leaf=1, learning_rate=1, n_estimators=300     |
+|                 0.6644 | max_features="log2", max_depth=7, min_samples_leaf=7, learning_rate=1, n_estimators=500     |
+|                 0.6578 | max_features="log2", max_depth=7, min_samples_leaf=1, learning_rate=1, n_estimators=500     |
+|                 0.6533 | max_features="log2", max_depth=7, min_samples_leaf=5, learning_rate=1, n_estimators=300     |
+|                 0.653  | max_features="log2", max_depth=7, min_samples_leaf=1, learning_rate=1, n_estimators=700     |
+|                 0.6504 | max_features="log2", max_depth=7, min_samples_leaf=3, learning_rate=1, n_estimators=500     |
+|                 0.6403 | max_features="log2", max_depth=5, min_samples_leaf=3, learning_rate=1, n_estimators=500     |
+|                 0.6375 | max_features="log2", max_depth=1, min_samples_leaf=3, learning_rate=1, n_estimators=500     |
+|                 0.6367 | max_features="log2", max_depth=7, min_samples_leaf=7, learning_rate=1, n_estimators=700     |
+|                 0.6313 | max_features="log2", max_depth=1, min_samples_leaf=13, learning_rate=1, n_estimators=300    |
+|                 0.6232 | max_features="log2", max_depth=5, min_samples_leaf=13, learning_rate=1, n_estimators=500    |
+|                 0.6152 | max_features="log2", max_depth=1, min_samples_leaf=1, learning_rate=1, n_estimators=100     |
+|                 0.6145 | max_features="log2", max_depth=3, min_samples_leaf=7, learning_rate=1, n_estimators=700     |
+|                 0.6114 | max_features="log2", max_depth=7, min_samples_leaf=13, learning_rate=1, n_estimators=700    |
+|                 0.585  | max_features="log2", max_depth=5, min_samples_leaf=5, learning_rate=1, n_estimators=500     |
+|                 0.5831 | max_features="log2", max_depth=7, min_samples_leaf=5, learning_rate=1, n_estimators=500     |
 
 ## BernoulliNB
-|   roc_auc.labels.true | params   |
-|----------------------:|:---------|
-|                0.8735 |          |
+|   roc_auc.labels.false | params   |
+|-----------------------:|:---------|
+|                 0.8963 |          |
 
 ## LogisticRegression
-|   roc_auc.labels.true | params              |
-|----------------------:|:--------------------|
-|                0.9354 | penalty="l1", C=10  |
-|                0.9353 | penalty="l1", C=1   |
-|                0.9247 | penalty="l1", C=0.1 |
-|                0.779  | penalty="l2", C=1   |
-|                0.7338 | penalty="l2", C=0.1 |
-|                0.7293 | penalty="l2", C=10  |
+|   roc_auc.labels.false | params              |
+|-----------------------:|:--------------------|
+|                 0.9579 | C=1, penalty="l1"   |
+|                 0.9575 | C=0.1, penalty="l1" |
+|                 0.9561 | C=10, penalty="l1"  |
+|                 0.8191 | C=0.1, penalty="l2" |
+|                 0.8146 | C=1, penalty="l2"   |
+|                 0.8033 | C=10, penalty="l2"  |
+
+## RandomForestClassifier
+|   roc_auc.labels.false | params                                                                          |
+|-----------------------:|:--------------------------------------------------------------------------------|
+|                 0.9641 | criterion="entropy", max_features="log2", min_samples_leaf=7, n_estimators=640  |
+|                 0.9633 | criterion="entropy", max_features="log2", min_samples_leaf=5, n_estimators=640  |
+|                 0.9624 | criterion="entropy", max_features="log2", min_samples_leaf=5, n_estimators=80   |
+|                 0.9618 | criterion="entropy", max_features="log2", min_samples_leaf=13, n_estimators=320 |
+|                 0.9617 | criterion="entropy", max_features="log2", min_samples_leaf=13, n_estimators=160 |
+|                 0.9615 | criterion="entropy", max_features="log2", min_samples_leaf=5, n_estimators=160  |
+|                 0.9604 | criterion="entropy", max_features="log2", min_samples_leaf=13, n_estimators=640 |
+|                 0.9591 | criterion="entropy", max_features="log2", min_samples_leaf=5, n_estimators=320  |
+|                 0.9589 | criterion="gini", max_features="log2", min_samples_leaf=13, n_estimators=320    |
+|                 0.9587 | criterion="entropy", max_features="log2", min_samples_leaf=3, n_estimators=320  |
+|                 0.9585 | criterion="entropy", max_features="log2", min_samples_leaf=7, n_estimators=160  |
+|                 0.9585 | criterion="entropy", max_features="log2", min_samples_leaf=3, n_estimators=640  |
+|                 0.958  | criterion="gini", max_features="log2", min_samples_leaf=13, n_estimators=640    |
+|                 0.9568 | criterion="gini", max_features="log2", min_samples_leaf=13, n_estimators=160    |
+|                 0.9564 | criterion="entropy", max_features="log2", min_samples_leaf=7, n_estimators=320  |
+|                 0.9561 | criterion="entropy", max_features="log2", min_samples_leaf=7, n_estimators=40   |
+|                 0.956  | criterion="gini", max_features="log2", min_samples_leaf=5, n_estimators=640     |
+|                 0.9558 | criterion="entropy", max_features="log2", min_samples_leaf=7, n_estimators=80   |
+|                 0.9556 | criterion="entropy", max_features="log2", min_samples_leaf=3, n_estimators=160  |
+|                 0.9555 | criterion="entropy", max_features="log2", min_samples_leaf=13, n_estimators=40  |
+|                 0.9554 | criterion="gini", max_features="log2", min_samples_leaf=7, n_estimators=320     |
+|                 0.9545 | criterion="entropy", max_features="log2", min_samples_leaf=1, n_estimators=640  |
+|                 0.9544 | criterion="entropy", max_features="log2", min_samples_leaf=13, n_estimators=80  |
+|                 0.9543 | criterion="gini", max_features="log2", min_samples_leaf=7, n_estimators=640     |
+|                 0.954  | criterion="gini", max_features="log2", min_samples_leaf=5, n_estimators=160     |
+|                 0.9531 | criterion="gini", max_features="log2", min_samples_leaf=7, n_estimators=80      |
+|                 0.953  | criterion="entropy", max_features="log2", min_samples_leaf=1, n_estimators=320  |
+|                 0.9521 | criterion="gini", max_features="log2", min_samples_leaf=7, n_estimators=160     |
+|                 0.9514 | criterion="gini", max_features="log2", min_samples_leaf=5, n_estimators=320     |
+|                 0.9513 | criterion="gini", max_features="log2", min_samples_leaf=3, n_estimators=640     |
+|                 0.9508 | criterion="gini", max_features="log2", min_samples_leaf=3, n_estimators=320     |
+|                 0.9504 | criterion="gini", max_features="log2", min_samples_leaf=13, n_estimators=80     |
+|                 0.9495 | criterion="entropy", max_features="log2", min_samples_leaf=3, n_estimators=80   |
+|                 0.9494 | criterion="gini", max_features="log2", min_samples_leaf=7, n_estimators=40      |
+|                 0.9485 | criterion="gini", max_features="log2", min_samples_leaf=13, n_estimators=40     |
+|                 0.9483 | criterion="gini", max_features="log2", min_samples_leaf=1, n_estimators=640     |
+|                 0.9478 | criterion="gini", max_features="log2", min_samples_leaf=1, n_estimators=320     |
+|                 0.9456 | criterion="entropy", max_features="log2", min_samples_leaf=1, n_estimators=160  |
+|                 0.9453 | criterion="gini", max_features="log2", min_samples_leaf=5, n_estimators=80      |
+|                 0.9451 | criterion="entropy", max_features="log2", min_samples_leaf=5, n_estimators=40   |
+|                 0.9439 | criterion="gini", max_features="log2", min_samples_leaf=3, n_estimators=160     |
+|                 0.9431 | criterion="entropy", max_features="log2", min_samples_leaf=13, n_estimators=20  |
+|                 0.9423 | criterion="gini", max_features="log2", min_samples_leaf=1, n_estimators=160     |
+|                 0.9406 | criterion="gini", max_features="log2", min_samples_leaf=13, n_estimators=20     |
+|                 0.9401 | criterion="entropy", max_features="log2", min_samples_leaf=3, n_estimators=40   |
+|                 0.9393 | criterion="gini", max_features="log2", min_samples_leaf=3, n_estimators=40      |
+|                 0.9386 | criterion="gini", max_features="log2", min_samples_leaf=3, n_estimators=80      |
+|                 0.9331 | criterion="entropy", max_features="log2", min_samples_leaf=1, n_estimators=80   |
+|                 0.9324 | criterion="gini", max_features="log2", min_samples_leaf=5, n_estimators=40      |
+|                 0.932  | criterion="entropy", max_features="log2", min_samples_leaf=7, n_estimators=20   |
+|                 0.932  | criterion="gini", max_features="log2", min_samples_leaf=5, n_estimators=20      |
+|                 0.9302 | criterion="gini", max_features="log2", min_samples_leaf=7, n_estimators=20      |
+|                 0.9281 | criterion="entropy", max_features="log2", min_samples_leaf=13, n_estimators=10  |
+|                 0.9259 | criterion="gini", max_features="log2", min_samples_leaf=13, n_estimators=10     |
+|                 0.9259 | criterion="gini", max_features="log2", min_samples_leaf=3, n_estimators=20      |
+|                 0.9247 | criterion="entropy", max_features="log2", min_samples_leaf=1, n_estimators=40   |
+|                 0.9246 | criterion="entropy", max_features="log2", min_samples_leaf=5, n_estimators=20   |
+|                 0.9236 | criterion="entropy", max_features="log2", min_samples_leaf=7, n_estimators=10   |
+|                 0.9222 | criterion="gini", max_features="log2", min_samples_leaf=1, n_estimators=80      |
+|                 0.9168 | criterion="entropy", max_features="log2", min_samples_leaf=3, n_estimators=20   |
+|                 0.9129 | criterion="gini", max_features="log2", min_samples_leaf=7, n_estimators=10      |
+|                 0.912  | criterion="gini", max_features="log2", min_samples_leaf=1, n_estimators=40      |
+|                 0.9118 | criterion="gini", max_features="log2", min_samples_leaf=5, n_estimators=10      |
+|                 0.9082 | criterion="entropy", max_features="log2", min_samples_leaf=3, n_estimators=10   |
+|                 0.8995 | criterion="entropy", max_features="log2", min_samples_leaf=5, n_estimators=10   |
+|                 0.8924 | criterion="gini", max_features="log2", min_samples_leaf=3, n_estimators=10      |
+|                 0.8793 | criterion="entropy", max_features="log2", min_samples_leaf=1, n_estimators=20   |
+|                 0.877  | criterion="gini", max_features="log2", min_samples_leaf=1, n_estimators=20      |
+|                 0.8463 | criterion="gini", max_features="log2", min_samples_leaf=1, n_estimators=10      |
+|                 0.8424 | criterion="entropy", max_features="log2", min_samples_leaf=1, n_estimators=10   |
 


### PR DESCRIPTION
Retraining the damaging and goodfaith models for huwiki based off of a recent labeling campaign: https://labels.wmflabs.org/campaigns/huwiki/92/

This also includes an update to `merge_labels` utility, which will now handle revisions with an empty `autolabel` field. In the case that this field is empty, we assume the worst case which is `"needs_review": True`

