### PR TITLE
Pin versions of pytest and pytest-cov

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest
+pytest == 4.1
 codecov
-pytest-cov
+pytest-cov == 2.9
 flake8 >= 3.8.1, < 3.8.999


### PR DESCRIPTION
This is to fix a Travis error on Python 3.5:

pkg_resources.VersionConflict: (pytest 4.1.0 (/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages), Requirement.parse('pytest>=4.6'))