### PR TITLE
feat: add github action that pushes to PYPI

### DIFF
--- a/.github/workflows/publish_python_package.yml
+++ b/.github/workflows/publish_python_package.yml
@@ -1,0 +1,42 @@
+name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'editquality/about.py'
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.7"
+      - name: Install pypa/build
+        run: >-
+          python -m pip install build --user
+      - name: Build a binary wheel and a source tarball
+        run: >-
+          python -m
+          build
+          --sdist
+          --wheel
+          --outdir dist/
+          .
+
+      - name: Publish distribution 📦 to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_TEST_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: scoring-internal
+          password: ${{ secrets.PYPI_PASS }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.5.1] - 2022-12-21
+
+### Added
+* Add Github Action that build & pushes to PYPI index
+
 ## [0.5.0] - 2019-08-13
 
 ### Added

--- a/editquality/about.py
+++ b/editquality/about.py
@@ -1,5 +1,5 @@
 __name__ = "editquality"
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 __author__ = "Aaron Halfaker"
 __author_email__ = "ahalfaker@wikimedia.org"
 __description__ = "A library for performing automatic detection of the " + \


### PR DESCRIPTION
This PR adds a Github action that will push a new version of the revscoring package to the PYPI repository once these two conditions are met:

- New commit/PR is pushed to master branch
- `editquality/about.py` 

